### PR TITLE
Use lowercase 'build scan' where appropriate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ teamcity {
         descriptor {
             name = 'GradleBuildScanIntegration'
             displayName = 'Gradle Build Scan Integration'
-            description = 'Provides easy navigation from TeamCity builds to Gradle Build Scans'
+            description = 'Provides easy navigation from TeamCity builds to Gradle build scans'
             version = project.version
             vendorName = 'Etienne Studer'
 

--- a/src/main/resources/buildServerResources/buildScanCrumbSummary.jsp
+++ b/src/main/resources/buildServerResources/buildScanCrumbSummary.jsp
@@ -3,7 +3,7 @@
 <%@ include file="/include.jsp" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <tr>
-          <td class="st">Build Scan:</td>
+          <td class="st">Build scan:</td>
           <td class="st">
                <c:choose>
                    <c:when test="${buildScans.size()>1}">

--- a/src/main/resources/buildServerResources/buildScanPage.jsp
+++ b/src/main/resources/buildServerResources/buildScanPage.jsp
@@ -6,16 +6,16 @@
 <c:choose>
     <c:when test="${buildScans.size()>1}">
         <div>
-            Build Scans <a href="${buildScans.first().url}" target="_blank">${buildScans.first().id}</a><c:forEach items="${buildScans.all()}" var="buildScan" begin="1">, <a href="${buildScan.url}" target="_blank">${buildScan.id}</a></c:forEach> have been published.
+            Build scans <a href="${buildScans.first().url}" target="_blank">${buildScans.first().id}</a><c:forEach items="${buildScans.all()}" var="buildScan" begin="1">, <a href="${buildScan.url}" target="_blank">${buildScan.id}</a></c:forEach> have been published.
         </div>
     </c:when>
     <c:when test="${!buildScans.isEmpty()}">
-        <div>Build Scan <a href="${buildScans.first().url}" target="_blank">${buildScans.first().id}</a> has been published.</div>
+        <div>Build scan <a href="${buildScans.first().url}" target="_blank">${buildScans.first().id}</a> has been published.</div>
     </c:when>
     <c:otherwise>
         <div>
-            No Build Scan has been published.
-            Learn more about how to enable Gradle Build Scans <a href="https://scans.gradle.com/get-started" target="_blank">here</a>.
+            No build scans have been published.
+            Learn more about how to enable Gradle build scans <a href="https://scans.gradle.com/get-started" target="_blank">here</a>.
         </div>
     </c:otherwise>
 </c:choose>


### PR DESCRIPTION
Note that several instances of uppercase 'Build Scan(s)' still exist after this change:

```
$ git grep 'Build Scan'
README.md:[TeamCity](https://www.jetbrains.com/teamcity/) plugin that integrates with the Gradle Build Scan Service, the first service offered by [Gradle Cloud Services](https://gradle.com).
build.gradle:            displayName = 'Gradle Build Scan Integration'
src/main/java/nu/studer/teamcity/buildscan/BuildScanViewBuildTab.java:        super("Build Scan", "buildScan", pagePlaces, pluginDescriptor.getPluginResourcesPath("/buildScanPage.jsp"), buildServer);
```

These are places where any common noun would be capitalized, e.g. headings and titles, etc.

Note also that in the build scan crumb summary, "Build Scan:" has been changed to "Build scan:" in order to follow convention with the capitalization precedent set by the existing field "Triggered by:".

![summary](http://i.imgur.com/aUp2bEBl.png)