### PR TITLE
artifact storage for buildscan urls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ def snapshotVersion = RELEASE ? '' : buildTimestamp
 group = 'nu.studer'
 version = baseVersion + (snapshotVersion ? "-$snapshotVersion" : '')
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:28.1-jre'

--- a/src/main/java/nu/studer/teamcity/buildscan/internal/ArtifactBuildScanDataStore.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/internal/ArtifactBuildScanDataStore.java
@@ -1,0 +1,84 @@
+package nu.studer.teamcity.buildscan.internal;
+
+import com.google.common.base.Charsets;
+import jetbrains.buildServer.ArtifactsConstants;
+import jetbrains.buildServer.serverSide.SBuild;
+import nu.studer.teamcity.buildscan.BuildScanReference;
+import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class ArtifactBuildScanDataStore implements BuildScanDataStore {
+
+    private static final Logger LOGGER = Logger.getLogger("jetbrains.buildServer.BUILDSCAN");
+    private final ReadOnlyBuildScanDataStore fallbackDataStore;
+
+    public ArtifactBuildScanDataStore(ReadOnlyBuildScanDataStore fallbackDataStore) {
+        this.fallbackDataStore = fallbackDataStore;
+    }
+
+    @Override
+    public void mark(SBuild build) {
+        final Path buildScanFile = getBuildScanFile(build);
+        try {
+            createIfNotExists(buildScanFile);
+        } catch (IOException ex) {
+            LOGGER.error(String.format("Could not create buildscan file %s", buildScanFile), ex);
+        }
+    }
+
+    @Override
+    public void store(SBuild build, String buildScanUrl) {
+        final Path buildScanFile = getBuildScanFile(build);
+        try {
+            createIfNotExists(buildScanFile);
+            Files.write(buildScanFile, Collections.singletonList(buildScanUrl), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+            LOGGER.debug(String.format("Successfully stored buildscan url %s for build %s in directory %s", buildScanUrl, build.getBuildId(), build.getArtifactsDirectory()));
+        } catch (IOException ex) {
+            LOGGER.error(String.format("Could not store build scan url %s into buildscan file %s", buildScanUrl, buildScanFile), ex);
+        }
+    }
+
+    private void createIfNotExists(Path buildScanFile) throws IOException {
+        Files.createDirectories(buildScanFile.getParent());
+        if (!Files.exists(buildScanFile)) {
+            Files.createFile(buildScanFile);
+        }
+    }
+
+    @NotNull
+    private Path getBuildScanFile(SBuild build) {
+        return Paths.get(build.getArtifactsDirectory().getAbsolutePath(), ArtifactsConstants.TEAMCITY_ARTIFACTS_DIR, "buildscans", "buildscan_urls.txt");
+    }
+
+    @Override
+    public List<BuildScanReference> fetch(SBuild build) {
+        return fetchOrFallback(build);
+    }
+
+    @Nullable
+    private List<BuildScanReference> fetchOrFallback(SBuild build) {
+        final Path buildScanFile = getBuildScanFile(build);
+        List<BuildScanReference> result;
+        if (Files.exists(buildScanFile)) {
+            try {
+                result = Files.lines(buildScanFile, Charsets.UTF_8).map(scanUrl -> new BuildScanReference(Util.getBuildScanId(scanUrl), scanUrl)).collect(Collectors.toList());
+            } catch (IOException ex) {
+                LOGGER.error(String.format("Could not read buildscan file %s", buildScanFile), ex);
+                result = Collections.emptyList();
+            }
+        } else {
+            return fallbackDataStore.fetch(build);
+        }
+        return result;
+    }
+}

--- a/src/main/java/nu/studer/teamcity/buildscan/internal/ArtifactBuildScanDataStore.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/internal/ArtifactBuildScanDataStore.java
@@ -8,6 +8,7 @@ import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,6 +21,8 @@ import java.util.stream.Collectors;
 public final class ArtifactBuildScanDataStore implements BuildScanDataStore {
 
     private static final Logger LOGGER = Logger.getLogger("jetbrains.buildServer.BUILDSCAN");
+    public static final String BUILDSCANS_DIR = "buildscans";
+    public static final String BUILDSCAN_URLS_FILE = "buildscan_urls.txt";
     private final ReadOnlyBuildScanDataStore fallbackDataStore;
 
     public ArtifactBuildScanDataStore(ReadOnlyBuildScanDataStore fallbackDataStore) {
@@ -28,7 +31,7 @@ public final class ArtifactBuildScanDataStore implements BuildScanDataStore {
 
     @Override
     public void mark(SBuild build) {
-        final Path buildScanFile = getBuildScanFile(build);
+        final Path buildScanFile = getBuildScanFile(build.getArtifactsDirectory());
         try {
             createIfNotExists(buildScanFile);
         } catch (IOException ex) {
@@ -38,7 +41,7 @@ public final class ArtifactBuildScanDataStore implements BuildScanDataStore {
 
     @Override
     public void store(SBuild build, String buildScanUrl) {
-        final Path buildScanFile = getBuildScanFile(build);
+        final Path buildScanFile = getBuildScanFile(build.getArtifactsDirectory());
         try {
             createIfNotExists(buildScanFile);
             Files.write(buildScanFile, Collections.singletonList(buildScanUrl), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
@@ -56,8 +59,8 @@ public final class ArtifactBuildScanDataStore implements BuildScanDataStore {
     }
 
     @NotNull
-    private Path getBuildScanFile(SBuild build) {
-        return Paths.get(build.getArtifactsDirectory().getAbsolutePath(), ArtifactsConstants.TEAMCITY_ARTIFACTS_DIR, "buildscans", "buildscan_urls.txt");
+    Path getBuildScanFile(File directory) {
+        return Paths.get(directory.getAbsolutePath(), ArtifactsConstants.TEAMCITY_ARTIFACTS_DIR, BUILDSCANS_DIR, BUILDSCAN_URLS_FILE);
     }
 
     @Override
@@ -67,7 +70,7 @@ public final class ArtifactBuildScanDataStore implements BuildScanDataStore {
 
     @Nullable
     private List<BuildScanReference> fetchOrFallback(SBuild build) {
-        final Path buildScanFile = getBuildScanFile(build);
+        final Path buildScanFile = getBuildScanFile(build.getArtifactsDirectory());
         List<BuildScanReference> result;
         if (Files.exists(buildScanFile)) {
             try {

--- a/src/main/java/nu/studer/teamcity/buildscan/internal/BuildScanDataStore.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/internal/BuildScanDataStore.java
@@ -1,12 +1,8 @@
 package nu.studer.teamcity.buildscan.internal;
 
 import jetbrains.buildServer.serverSide.SBuild;
-import nu.studer.teamcity.buildscan.BuildScanReference;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
-
-public interface BuildScanDataStore {
+public interface BuildScanDataStore extends ReadOnlyBuildScanDataStore {
 
     /**
      * Stores an empty data set for the given build. Calls to {@link #fetch} differentiate between returning an empty
@@ -29,15 +25,4 @@ public interface BuildScanDataStore {
      * @param buildScanUrl the URL of the published build scan
      */
     void store(SBuild build, String buildScanUrl);
-
-    /**
-     * Returns the list of all build scans published by the given build. If the build published no scans an empty list
-     * is returned or {@code null} if no data exists for the requested build.
-     *
-     * @param build the requested build
-     * @return all published scans for the given build or {@code null} if no data exists for the given build
-     */
-    @Nullable
-    List<BuildScanReference> fetch(SBuild build);
-
 }

--- a/src/main/java/nu/studer/teamcity/buildscan/internal/CustomDatastoreBuildScanDataStore.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/internal/CustomDatastoreBuildScanDataStore.java
@@ -1,24 +1,36 @@
 package nu.studer.teamcity.buildscan.internal;
 
-import jetbrains.buildServer.serverSide.CustomDataStorage;
-import jetbrains.buildServer.serverSide.SBuild;
+import com.google.common.collect.Maps;
+import jetbrains.buildServer.Build;
+import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.util.StringUtil;
 import nu.studer.teamcity.buildscan.BuildScanReference;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 
-public final class CustomDatastoreBuildScanDataStore implements ReadOnlyBuildScanDataStore {
+public final class CustomDatastoreBuildScanDataStore extends BuildServerAdapter implements ReadOnlyBuildScanDataStore {
 
     private static final String BUILD_SCAN_STORAGE_ID = "nu.studer.teamcity.buildscan.DefaultBuildScanDataStore";
     private static final String BUILD_SCAN_URLS_SEPARATOR = "|";
+    private final SBuildServer server;
+
+    public CustomDatastoreBuildScanDataStore(SBuildServer buildServer) {
+        server = buildServer;
+    }
+
+    @SuppressWarnings("unused")
+    public void register() {
+        server.addListener(this);
+    }
 
     @Override
     public List<BuildScanReference> fetch(SBuild build) {
         String buildId = String.valueOf(build.getBuildId());
-        CustomDataStorage customDataStorage = getCustomDataStorage(build);
+        //noinspection ConstantConditions
+        CustomDataStorage customDataStorage = getCustomDataStorage(build.getBuildType());
         String existing = customDataStorage.getValue(buildId);
 
         if (existing == null) {
@@ -31,14 +43,41 @@ public final class CustomDatastoreBuildScanDataStore implements ReadOnlyBuildSca
                     buildScanReferences.add(new BuildScanReference(Util.getBuildScanId(scanUrl), scanUrl));
                 }
             }
-
             return buildScanReferences;
         }
     }
 
     @NotNull
-    private CustomDataStorage getCustomDataStorage(SBuild build) {
-        //noinspection ConstantConditions
-        return build.getBuildType().getCustomDataStorage(BUILD_SCAN_STORAGE_ID);
+    private CustomDataStorage getCustomDataStorage(SBuildType buildType) {
+        return buildType.getCustomDataStorage(BUILD_SCAN_STORAGE_ID);
+    }
+
+    @Override
+    public void entriesDeleted(@NotNull Collection<SFinishedBuild> removedEntries) {
+        for (SFinishedBuild removedEntry : removedEntries) {
+            //noinspection ConstantConditions
+            final CustomDataStorage customDataStorage = getCustomDataStorage(removedEntry.getBuildType());
+            cleanupDeletedValues(customDataStorage);
+        }
+    }
+
+    @Override
+    public void cleanupFinished() {
+        final List<SBuildType> activeBuildTypes = server.getProjectManager().getActiveBuildTypes();
+        for (SBuildType activeBuildType : activeBuildTypes) {
+            final CustomDataStorage customDataStorage = getCustomDataStorage(activeBuildType);
+            cleanupDeletedValues(customDataStorage);
+        }
+    }
+
+    private void cleanupDeletedValues(CustomDataStorage customDataStorage) {
+        final Map<String, String> buildScans = customDataStorage.getValues();
+        if (buildScans != null && !buildScans.isEmpty()) {
+            List<Long> scanBuildIds = buildScans.keySet().stream().map(Long::parseLong).collect(Collectors.toList());
+            final Collection<SFinishedBuild> availableBuilds = server.getHistory().findEntries(scanBuildIds);
+            final Set<Long> availableBuildIds = availableBuilds.stream().map(Build::getBuildId).collect(Collectors.toSet());
+            final Map<String, String> availableBuildsOnly = Maps.filterEntries(buildScans, input -> input != null && availableBuildIds.contains(Long.parseLong(input.getKey())));
+            customDataStorage.putValues(availableBuildsOnly);
+        }
     }
 }

--- a/src/main/java/nu/studer/teamcity/buildscan/internal/CustomDatastoreBuildScanDataStore.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/internal/CustomDatastoreBuildScanDataStore.java
@@ -9,40 +9,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-public final class DefaultBuildScanDataStore implements BuildScanDataStore {
+
+public final class CustomDatastoreBuildScanDataStore implements ReadOnlyBuildScanDataStore {
 
     private static final String BUILD_SCAN_STORAGE_ID = "nu.studer.teamcity.buildscan.DefaultBuildScanDataStore";
     private static final String BUILD_SCAN_URLS_SEPARATOR = "|";
-
-    @Override
-    public void mark(SBuild build) {
-        String buildId = String.valueOf(build.getBuildId());
-        CustomDataStorage customDataStorage = getCustomDataStorage(build);
-        String existing = customDataStorage.getValue(buildId);
-
-        if (existing == null) {
-            customDataStorage.putValue(buildId, "");
-            customDataStorage.flush();
-        }
-    }
-
-    @Override
-    public void store(SBuild build, String buildScanUrl) {
-        String buildId = String.valueOf(build.getBuildId());
-        CustomDataStorage customDataStorage = getCustomDataStorage(build);
-        String existing = customDataStorage.getValue(buildId);
-
-        if (existing == null || existing.isEmpty()) {
-            customDataStorage.putValue(buildId, buildScanUrl);
-            customDataStorage.flush();
-        } else {
-            List<String> scans = StringUtil.split(existing, BUILD_SCAN_URLS_SEPARATOR);
-            scans.add(buildScanUrl);
-
-            customDataStorage.putValue(buildId, StringUtil.join(BUILD_SCAN_URLS_SEPARATOR, scans));
-            customDataStorage.flush();
-        }
-    }
 
     @Override
     public List<BuildScanReference> fetch(SBuild build) {
@@ -70,5 +41,4 @@ public final class DefaultBuildScanDataStore implements BuildScanDataStore {
         //noinspection ConstantConditions
         return build.getBuildType().getCustomDataStorage(BUILD_SCAN_STORAGE_ID);
     }
-
 }

--- a/src/main/java/nu/studer/teamcity/buildscan/internal/ReadOnlyBuildScanDataStore.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/internal/ReadOnlyBuildScanDataStore.java
@@ -1,0 +1,21 @@
+package nu.studer.teamcity.buildscan.internal;
+
+import jetbrains.buildServer.serverSide.SBuild;
+import nu.studer.teamcity.buildscan.BuildScanReference;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public interface ReadOnlyBuildScanDataStore {
+
+    /**
+     * Returns the list of all build scans published by the given build. If the build published no scans an empty list
+     * is returned or {@code null} if no data exists for the requested build.
+     *
+     * @param build the requested build
+     * @return all published scans for the given build or {@code null} if no data exists for the given build
+     */
+    @Nullable
+    List<BuildScanReference> fetch(SBuild build);
+
+}

--- a/src/main/resources/META-INF/build-server-plugin-buildscans.xml
+++ b/src/main/resources/META-INF/build-server-plugin-buildscans.xml
@@ -34,7 +34,7 @@
     <bean id="buildScanServiceMessageListener"
           class="nu.studer.teamcity.buildscan.internal.BuildScanServiceMessageListener"/>
 
-    <bean id="customStorageBuildScanDataStore"
+    <bean id="customStorageBuildScanDataStore" init-method="register"
           class="nu.studer.teamcity.buildscan.internal.CustomDatastoreBuildScanDataStore">
     </bean>
 

--- a/src/main/resources/META-INF/build-server-plugin-buildscans.xml
+++ b/src/main/resources/META-INF/build-server-plugin-buildscans.xml
@@ -34,8 +34,14 @@
     <bean id="buildScanServiceMessageListener"
           class="nu.studer.teamcity.buildscan.internal.BuildScanServiceMessageListener"/>
 
+    <bean id="customStorageBuildScanDataStore"
+          class="nu.studer.teamcity.buildscan.internal.CustomDatastoreBuildScanDataStore">
+    </bean>
+
     <bean id="buildScanDataStore"
-          class="nu.studer.teamcity.buildscan.internal.DefaultBuildScanDataStore"/>
+          class="nu.studer.teamcity.buildscan.internal.ArtifactBuildScanDataStore">
+        <constructor-arg type="nu.studer.teamcity.buildscan.internal.ReadOnlyBuildScanDataStore" ref="customStorageBuildScanDataStore"/>
+     </bean>
 
     <bean id="buildScanDisplayArbiter"
           class="nu.studer.teamcity.buildscan.internal.DefaultBuildScanDisplayArbiter"/>

--- a/src/test/groovy/nu/studer/teamcity/buildscan/internal/ArtifactBuildScanDataStoreTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/internal/ArtifactBuildScanDataStoreTest.groovy
@@ -1,0 +1,76 @@
+package nu.studer.teamcity.buildscan.internal
+
+import jetbrains.buildServer.serverSide.SBuild
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.file.Files
+
+class ArtifactBuildScanDataStoreTest extends Specification {
+
+    ReadOnlyBuildScanDataStore fallBackStore = Mock()
+    ArtifactBuildScanDataStore store
+
+    @Rule
+    TemporaryFolder tempDir = new TemporaryFolder()
+
+    File artifactsFolder
+
+    void setup() {
+        store = new ArtifactBuildScanDataStore(fallBackStore)
+        artifactsFolder = tempDir.newFolder()
+    }
+
+    def "empty buildscan file is created when build is started"() {
+        given:
+        SBuild build = Mock()
+
+        when:
+        store.mark(build)
+
+        then:
+        build.artifactsDirectory >> artifactsFolder
+        Files.exists(store.getBuildScanFile(artifactsFolder))
+    }
+
+    @Unroll
+    def "build scans are stored in text file line by line"() {
+        given:
+        SBuild build = Mock()
+
+        when:
+        urls.each { scanUrl ->
+            store.store(build, scanUrl)
+        }
+
+        then:
+        build.artifactsDirectory >> artifactsFolder
+        store.getBuildScanFile(artifactsFolder).readLines() == urls
+
+        where:
+        urls << [['http://gradle.com/s/1'], ['http://gradle.com/s/1', 'http://gradle.com/s/2']]
+
+    }
+
+    @Unroll
+    def "fetch build scan references contain previously persisted build scan urls"() {
+        given:
+        SBuild build = Mock()
+
+        when:
+        urls.each { scanUrl ->
+            store.store(build, scanUrl)
+        }
+        def scanReferences = store.fetch(build)
+
+        then:
+        build.artifactsDirectory >> artifactsFolder
+        scanReferences.collect { it.url } == urls
+
+        where:
+        urls << [['http://gradle.com/s/1'], ['http://gradle.com/s/1', 'http://gradle.com/s/2']]
+
+    }
+}


### PR DESCRIPTION
Buildscan urls are stored inside the artifacts repository and have therefore the same lifecycle as the teamcity build  

resolves  #13 