### PR TITLE
Add unique hint to BuildScanServiceMessageMavenExtension

### DIFF
--- a/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
+++ b/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
@@ -10,7 +10,7 @@ import org.codehaus.plexus.logging.Logger;
 
 import javax.inject.Inject;
 
-@Component(role = AbstractMavenLifecycleParticipant.class)
+@Component(role = AbstractMavenLifecycleParticipant.class, hint = "teamcity-build-scan-plugin")
 public final class BuildScanServiceMessageMavenExtension extends AbstractMavenLifecycleParticipant {
 
     private final PlexusContainer container;


### PR DESCRIPTION
TeamCity applies its own Maven extensions with the same (i.e. `null`) hint. This causes a silent conflict and only one extension is resolved / applied - ours - causing the rest of the build pipeline completely lost resulting with unexpected behaviour. 

When we added a unique hint we printed out participants list 

```java
@Requirement
private List<AbstractMavenLifecycleParticipant> participantList;
```

we got this in the logs:

```
participantList = [com.jetbrains.maven.watcher.m3wrp.MavenLifecycleParticipant@7fcff1b9, nu.studer.teamcity.buildscan.agent.servicemessage.BuildScanServiceMessageMavenExtension@66eb985d]
```

which proves that we have more than one extension applied to the Maven build.

Adding a unique hint is equivalent of giving the "bean" a unique id / name.

Fixes #16