### PR TITLE
Change logic to install buildPublishedActions in build-scan-init.gradle

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'groovy'
     id 'com.github.rodm.teamcity-agent'
 }
 
@@ -8,10 +9,37 @@ configurations {
         canBeConsumed = false
         canBeResolved = true
     }
+    teamCityInitClasspath {
+        canBeConsumed = false
+        canBeResolved = true
+    }
+}
+
+sourceSets {
+    mockBuildScanPlugin {
+        groovy {
+            srcDir 'src/mockBuildScanPlugin/groovy'
+        }
+    }
+}
+
+repositories {
+    jcenter()
 }
 
 dependencies {
     mvnExtension project(path: ':agent:service-message-maven-extension', configuration: 'mvnExtension')
+
+    teamCityInitClasspath 'org.jetbrains.teamcity:serviceMessages:2020.1.1'
+    testImplementation gradleTestKit()
+    testImplementation 'org.spockframework:spock-core:2.0-M3-groovy-2.5'
+    testImplementation 'org.spockframework:spock-junit4:2.0-M3-groovy-2.5'
+    testImplementation 'io.ratpack:ratpack-groovy-test:1.7.5', {
+        exclude module: 'groovy-all'
+    }
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1'
+
+    mockBuildScanPluginCompileOnly gradleApi()
 }
 
 processResources {
@@ -27,4 +55,43 @@ teamcity {
             }
         }
     }
+}
+
+def mockPluginJar = tasks.register('mockPluginJar', Jar) {
+    it.from sourceSets.mockBuildScanPlugin.output
+    it.archiveBaseName.set('mockBuildScanPlugin')
+}
+
+test {
+    useJUnitPlatform()
+    jvmArgumentProviders.add(new TeamCityInitClasspathCommandLineArgumentProvider(teamCityInitClasspath: configurations.teamCityInitClasspath))
+    jvmArgumentProviders.add(new MockPluginJarCommandLineArgumentProvider(mockPluginJar: mockPluginJar))
+}
+
+final class TeamCityInitClasspathCommandLineArgumentProvider implements CommandLineArgumentProvider {
+
+    @Classpath
+    FileCollection teamCityInitClasspath
+
+    @Override
+    Iterable<String> asArguments() {
+        [
+                "-DteamCityInitClasspath=${teamCityInitClasspath.files.join(File.pathSeparator)}"
+        ]
+    }
+
+}
+
+final class MockPluginJarCommandLineArgumentProvider implements CommandLineArgumentProvider {
+
+    @Classpath
+    TaskProvider<Jar> mockPluginJar
+
+    @Override
+    Iterable<String> asArguments() {
+        [
+                "-DmockPluginJar=${mockPluginJar.get().outputs.files.singleFile.absolutePath}"
+        ]
+    }
+
 }

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -18,7 +18,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GRADLE_RUNNER = "gradle-runner";
     private static final String GRADLE_CMD_PARAMS = "ui.gradleRunner.additional.gradle.cmd.params";
-    private static final String BUILD_SCAN_INIT_GRADLE = "build-scan-init.gradle";
+    static final String BUILD_SCAN_INIT_GRADLE = "build-scan-init.gradle";
 
     private static final String MAVEN_RUNNER = "Maven2";
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -1,6 +1,9 @@
 import jetbrains.buildServer.messages.serviceMessages.ServiceMessage
+import org.gradle.util.GradleVersion
 
-if (!gradleVersionSupported()) {
+def gradleVersion = GradleVersion.current()
+
+if (!gradleVersionSupported(gradleVersion)) {
     return
 }
 
@@ -16,7 +19,7 @@ def serviceMessageName = 'nu.studer.teamcity.buildscan.buildScanLifeCycle'
 logger.quiet(ServiceMessage.asString(serviceMessageName, 'BUILD_STARTED').toString())
 
 def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
-def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
 
 def buildScanPublishedAction = { def buildScan ->
     if (buildScan.metaClass.respondsTo(buildScan, 'buildScanPublished', Action)) {
@@ -26,34 +29,27 @@ def buildScanPublishedAction = { def buildScan ->
     }
 }
 
-// Gradle 4.1+ and 5.+
-rootProject {
-    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-        buildScanPublishedAction(buildScan)
+if (gradleVersion < GradleVersion.version('6.0')) {
+    // Gradle 4.1+ and 5.+
+    rootProject {
+        pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+            buildScanPublishedAction(buildScan)
+        }
+    }
+} else {
+    // Gradle 6.+
+    gradle.settingsEvaluated { settings ->
+        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each {
+            buildScanPublishedAction(settings[it.name].buildScan)
+        }
     }
 }
 
-// Gradle 6.+
-gradle.settingsEvaluated { settings ->
-    settings.pluginManager.withPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) {
-        buildScanPublishedAction(settings.gradleEnterprise.buildScan)
-    }
+static def extensionsWithPublicType(def container, String publicType) {
+    container.extensions.extensionsSchema.elements.findAll { it.publicType.concreteClass.name == publicType }
 }
 
 // require at least Gradle 4.1 (build scan plugin 1.8)
-boolean gradleVersionSupported() {
-    def parts = gradle.gradleVersion.split('\\.')
-    if (parts.length < 2) {
-        false
-    } else {
-        def major = parts[0]
-        def minor = parts[1]
-        if (major < '4') {
-            false
-        } else if (major == '4' && minor < '1') {
-            false
-        } else {
-            true
-        }
-    }
+static boolean gradleVersionSupported(GradleVersion gradleVersion) {
+    gradleVersion >= GradleVersion.version('4.1')
 }

--- a/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/BuildScanExtension.groovy
+++ b/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/BuildScanExtension.groovy
@@ -1,0 +1,11 @@
+package com.gradle.enterprise.gradleplugin
+
+import org.gradle.api.Action
+
+interface BuildScanExtension {
+
+    void buildScanPublished(Action<? super PublishedBuildScan> action)
+    
+    void buildFinished()
+    
+}

--- a/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/DefaultBuildScanExtension.groovy
+++ b/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/DefaultBuildScanExtension.groovy
@@ -1,0 +1,39 @@
+package com.gradle.enterprise.gradleplugin
+
+import org.gradle.api.Action
+
+import javax.inject.Inject
+
+class DefaultBuildScanExtension implements BuildScanExtension {
+
+    private final List<Action<? super PublishedBuildScan>> buildScanPublishedActions
+
+    @Inject
+    DefaultBuildScanExtension() {
+        this.buildScanPublishedActions = []
+    }
+
+    @Override
+    void buildScanPublished(Action<? super PublishedBuildScan> action) {
+        buildScanPublishedActions.add(action)
+    }
+
+    @Override
+    void buildFinished() {
+        def publishedBuildScan = new PublishedBuildScan() {
+            @Override
+            String getBuildScanId() {
+                'buildScanID'
+            }
+
+            @Override
+            URI getBuildScanUri() {
+                URI.create('https://server.com/' + buildScanId)
+            }
+        }
+        buildScanPublishedActions.each {
+            it.execute(publishedBuildScan)
+        }
+    }
+
+}

--- a/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/DefaultGradleEnterpriseExtension.groovy
+++ b/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/DefaultGradleEnterpriseExtension.groovy
@@ -1,0 +1,26 @@
+package com.gradle.enterprise.gradleplugin
+
+import org.gradle.api.Action
+
+import javax.inject.Inject
+
+class DefaultGradleEnterpriseExtension implements GradleEnterpriseExtension {
+
+    private final BuildScanExtension buildScanExtension
+
+    @Inject
+    DefaultGradleEnterpriseExtension(BuildScanExtension buildScanExtension) {
+        this.buildScanExtension = buildScanExtension
+    }
+
+    @Override
+    BuildScanExtension getBuildScan() {
+        buildScanExtension
+    }
+
+    @Override
+    void buildScan(Action<? super BuildScanExtension> action) {
+        action.execute(getBuildScan())
+    }
+
+}

--- a/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/GradleEnterpriseExtension.groovy
+++ b/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/GradleEnterpriseExtension.groovy
@@ -1,0 +1,11 @@
+package com.gradle.enterprise.gradleplugin
+
+import org.gradle.api.Action
+
+interface GradleEnterpriseExtension {
+
+    BuildScanExtension getBuildScan()
+
+    void buildScan(Action<? super BuildScanExtension> action)
+
+}

--- a/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/MockPlugin.groovy
+++ b/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/MockPlugin.groovy
@@ -1,0 +1,58 @@
+package com.gradle.enterprise.gradleplugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.model.ObjectFactory
+import org.gradle.internal.service.ServiceRegistry
+
+class MockPlugin implements Plugin<Object> {
+
+    @Override
+    void apply(Object object) {
+        if (object instanceof Settings) {
+            doApplySettings((Settings) object)
+        } else {
+            doApplyProject((Project) object)
+        }
+    }
+
+    static void doApplySettings(Settings settings) {
+        boolean pluginAlreadyApplied = pluginAlreadyApplied(settings)
+        GradleInternal gradleInternal = (GradleInternal) settings.gradle
+        def extension = createGradleEnterpriseExtension(gradleInternal.services)
+        settings.extensions.add(GradleEnterpriseExtension.class, pluginAlreadyApplied ? 'gradleEnterprise2' : 'gradleEnterprise1', extension)
+        gradleInternal.rootProject { Project project ->
+            project.extensions.add(GradleEnterpriseExtension.class, pluginAlreadyApplied ? 'gradleEnterprise2' : 'gradleEnterprise1', extension)
+            project.extensions.add(BuildScanExtension.class, pluginAlreadyApplied ? 'buildScan2' : 'buildScan1', extension.buildScan)
+        }
+        gradleInternal.buildFinished {
+            extension.buildScan.buildFinished()
+        }
+    }
+
+    static void doApplyProject(Project project) {
+        GradleInternal gradleInternal = (GradleInternal) project.gradle
+        def extension = createBuildScanExtension(gradleInternal.services)
+        project.extensions.add(BuildScanExtension.class, 'buildScan', extension)
+    }
+
+    private static GradleEnterpriseExtension createGradleEnterpriseExtension(ServiceRegistry serviceRegistry) {
+        ObjectFactory objectFactory = serviceRegistry.get(ObjectFactory.class)
+        objectFactory.newInstance(
+                DefaultGradleEnterpriseExtension.class,
+                createBuildScanExtension(serviceRegistry)
+        )
+    }
+
+    private static BuildScanExtension createBuildScanExtension(ServiceRegistry serviceRegistry) {
+        ObjectFactory objectFactory = serviceRegistry.get(ObjectFactory.class)
+        objectFactory.newInstance(DefaultBuildScanExtension.class)
+    }
+
+    private static boolean pluginAlreadyApplied(Settings settings) {
+        return settings.getPlugins().stream().anyMatch { plugin -> plugin.getClass().getName() == MockPlugin.class.getName() }
+    }
+
+}

--- a/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/PublishedBuildScan.groovy
+++ b/agent/src/mockBuildScanPlugin/groovy/com/gradle/enterprise/gradleplugin/PublishedBuildScan.groovy
@@ -1,0 +1,9 @@
+package com.gradle.enterprise.gradleplugin
+
+interface PublishedBuildScan {
+
+    String getBuildScanId()
+
+    URI getBuildScanUri()
+
+}

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/BaseInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/BaseInitScriptTest.groovy
@@ -1,0 +1,42 @@
+package nu.studer.teamcity.buildscan.agent
+
+import jetbrains.buildServer.util.FileUtil
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static nu.studer.teamcity.buildscan.agent.BuildScanServiceMessageInjector.BUILD_SCAN_INIT_GRADLE
+
+class BaseInitScriptTest extends Specification {
+
+    private static final String TEAMCITY_BUILD_INIT_CLASS_PATH_SYS_PROP = 'teamCityInitClasspath'
+
+    @Rule
+    TemporaryFolder testProjectDir = new TemporaryFolder()
+    File settingsFile
+    File initScriptFile
+
+    def setup() {
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        initScriptFile = testProjectDir.newFile('initscript.gradle')
+        FileUtil.copyResource(BuildScanServiceMessageInjector.class, '/' + BUILD_SCAN_INIT_GRADLE, initScriptFile)
+    }
+
+    BuildResult run(GradleVersion gradleVersion = GradleVersion.current()) {
+        def args = ['tasks', '-I', initScriptFile.absolutePath]
+        GradleRunner.create()
+                .withGradleVersion(gradleVersion.version)
+                .withProjectDir(testProjectDir.root)
+                .withArguments(args)
+                .withEnvironment(['TEAMCITY_BUILD_INIT_PATH': System.getProperty(TEAMCITY_BUILD_INIT_CLASS_PATH_SYS_PROP)])
+                .build()
+    }
+
+    static void outputContainsTeamCityServiceMessageBuildStarted(BuildResult result) {
+        assert result.output.contains("##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_STARTED']")
+    }
+
+}

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/BuildScanInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/BuildScanInitScriptTest.groovy
@@ -1,0 +1,156 @@
+package nu.studer.teamcity.buildscan.agent
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.smile.SmileFactory
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.util.GradleVersion
+import ratpack.groovy.test.embed.GroovyEmbeddedApp
+import spock.lang.AutoCleanup
+
+import java.util.zip.GZIPOutputStream
+
+class BuildScanInitScriptTest extends BaseInitScriptTest {
+
+    private static final String PUBLIC_BUILD_SCAN_ID = 'i2wepy2gr7ovw'
+    private static final String DEFAULT_SCAN_UPLOAD_TOKEN = 'scan-upload-token'
+
+    private static final List<GradleVersion> GRADLE_VERSIONS = [
+            GradleVersion.version('4.10.3'),
+            GradleVersion.version('5.6.4'),
+            GradleVersion.current()
+    ]
+
+    @AutoCleanup
+    def mockScansServer = GroovyEmbeddedApp.of {
+        def jsonWriter = new ObjectMapper(new JsonFactory()).writer()
+        def smileWriter = new ObjectMapper(new SmileFactory()).writer()
+        handlers {
+            post('in/:gradleVersion/:pluginVersion') {
+                def scanUrlString = "${mockScansServer.address}s/" + PUBLIC_BUILD_SCAN_ID
+                def body = [
+                        id: PUBLIC_BUILD_SCAN_ID,
+                        scanUrl: scanUrlString.toString(),
+                ]
+                context.response
+                        .contentType('application/vnd.gradle.scan-ack')
+                        .send(gzip(smileWriter.writeValueAsBytes(body)))
+            }
+            prefix('scans/publish') {
+                post('gradle/:pluginVersion/token') {
+                    def pluginVersion = context.pathTokens.pluginVersion
+                    def scanUrlString = "${mockScansServer.address}s/" + PUBLIC_BUILD_SCAN_ID
+                    def body = [
+                            id: PUBLIC_BUILD_SCAN_ID,
+                            scanUrl: scanUrlString.toString(),
+                            scanUploadUrl: "${mockScansServer.address.toString()}scans/publish/gradle/$pluginVersion/upload".toString(),
+                            scanUploadToken: DEFAULT_SCAN_UPLOAD_TOKEN
+                    ]
+                    context.response
+                            .contentType('application/vnd.gradle.scan-ack+json')
+                            .send(jsonWriter.writeValueAsBytes(body))
+                }
+                post('gradle/:pluginVersion/upload') {
+                    context.request.getBody(1024 * 1024 * 10).then {
+                        context.response
+                                .contentType('application/vnd.gradle.scan-upload-ack+json')
+                                .send()
+                    }
+                }
+                notFound()
+            }
+        }
+    }
+
+    File buildFile
+
+    def setup() {
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    def "can use build-scan init script without declaring build scan / Gradle Enterprise plugin (#gradleVersion)"() {
+        when:
+        def result = run(gradleVersion)
+
+        then:
+        outputContainsTeamCityServiceMessageBuildStarted(result)
+
+        where:
+        gradleVersion << GRADLE_VERSIONS
+    }
+
+    def "can use build-scan init script in conjunction with the build scan / Gradle Enterprise plugin (#gradleVersion)"() {
+        given:
+        settingsFile << maybeAddGradleEnterprisePlugin(gradleVersion)
+        buildFile << maybeAddBuildScanPlugin(gradleVersion)
+
+        when:
+        def result = run(gradleVersion)
+
+        then:
+        outputContainsTeamCityServiceMessageBuildStarted(result)
+        teamCityServiceMessageBuildScanUrl(result)
+
+        where:
+        gradleVersion << GRADLE_VERSIONS
+    }
+
+    private String maybeAddGradleEnterprisePlugin(GradleVersion gradleVersion) {
+        if (gradleVersion < GradleVersion.version('5.0')) {
+            '' // applied in build.gradle
+        } else if (gradleVersion < GradleVersion.version('6.0')) {
+            '' // applied in build.gradle
+        } else {
+            """
+              plugins {
+                id 'com.gradle.enterprise' version '3.4.1'
+              }
+              gradleEnterprise {
+                server = '${mockScansServer.address}'
+                buildScan {
+                  publishAlways()
+                }
+              }
+            """
+        }
+    }
+
+    private String maybeAddBuildScanPlugin(GradleVersion gradleVersion) {
+        if (gradleVersion < GradleVersion.version('5.0')) {
+            """
+              plugins {
+                id 'com.gradle.build-scan' version '1.16'
+              }
+              buildScan {
+                server = '${mockScansServer.address}'
+                publishAlways()
+              }
+            """
+        } else if (gradleVersion < GradleVersion.version('6.0')) {
+            """
+              plugins {
+                id 'com.gradle.build-scan' version '3.4.1'
+              }
+              gradleEnterprise {
+                server = '${mockScansServer.address}'
+                buildScan {
+                  publishAlways()
+                }
+              }
+            """
+        } else {
+            '' // applied in settings.gradle
+        }
+    }
+
+    private void teamCityServiceMessageBuildScanUrl(BuildResult result) {
+        assert result.output.contains("##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_SCAN_URL:${mockScansServer.address}s/$PUBLIC_BUILD_SCAN_ID']")
+    }
+
+    private static byte[] gzip(byte[] bytes) {
+        def out = new ByteArrayOutputStream()
+        new GZIPOutputStream(out).withStream { it.write(bytes) }
+        out.toByteArray()
+    }
+
+}

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/MockBuildScanInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/MockBuildScanInitScriptTest.groovy
@@ -1,0 +1,54 @@
+package nu.studer.teamcity.buildscan.agent
+
+import org.gradle.testkit.runner.BuildResult
+
+class MockBuildScanInitScriptTest extends BaseInitScriptTest {
+
+    private static final String MOCK_PLUGIN_JAR_SYS_PROP = 'mockPluginJar'
+    File mockPluginJar
+    File mockPluginJar2
+
+    def setup() {
+        mockPluginJar = new File(System.getProperty(MOCK_PLUGIN_JAR_SYS_PROP))
+        mockPluginJar2 = new File(mockPluginJar.parent, 'mockPluginJar2.jar')
+        mockPluginJar2.bytes = mockPluginJar.bytes
+    }
+
+    def "properly reacts to multiple applications"() {
+        given:
+        def firstApplication = testProjectDir.newFile('first.gradle')
+        firstApplication << mockPluginApplication(mockPluginJar)
+        def secondApplication = testProjectDir.newFile('second.gradle')
+        secondApplication << mockPluginApplication(mockPluginJar2)
+        settingsFile << """
+          apply from: '${firstApplication.absolutePath}'
+          apply from: '${secondApplication.absolutePath}'
+        """
+
+        when:
+        def result = run()
+
+        then:
+        outputContainsTeamCityServiceMessageBuildStarted(result)
+        outputContainsTwoTeamCityServiceMessageBuildScanUrl(result)
+    }
+
+    private static String mockPluginApplication(File mockPluginJar) {
+        """
+          buildscript {
+            dependencies {
+              classpath(files("${mockPluginJar.absolutePath}"))
+            }
+          }
+          apply plugin: getClass().classLoader.loadClass('com.gradle.enterprise.gradleplugin.MockPlugin')
+        """
+    }
+
+    private static void outputContainsTwoTeamCityServiceMessageBuildScanUrl(BuildResult result) {
+        assert result.output.contains("""
+##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_SCAN_URL:https://server.com/buildScanID']
+##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_SCAN_URL:https://server.com/buildScanID']
+""")
+    }
+
+}


### PR DESCRIPTION
This PR tweaks a bit the way the TC build scan plugin works with Gradle 6.+, to register its `buildScanPublishedAction`.

I also added test coverage using real build scan / Gradle Enterprise plugins, and latest Gradle version from the support major streams (4.x, 5.x, 6.x)
I added a test with a double application using a mocked plugin.