### PR TITLE
Support plugin reload by unregistering the listener

### DIFF
--- a/src/main/java/nu/studer/teamcity/buildscan/BuildScanBuildServerListener.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/BuildScanBuildServerListener.java
@@ -39,6 +39,11 @@ public final class BuildScanBuildServerListener extends BuildServerAdapter {
         LOGGER.info(String.format("Registered %s. %s-%s", getClass().getSimpleName(), pluginDescriptor.getPluginName(), pluginDescriptor.getPluginVersion()));
     }
 
+    public void unregister() {
+        buildServer.removeListener(this);
+        LOGGER.info(String.format("Unregistered %s. %s-%s", getClass().getSimpleName(), pluginDescriptor.getPluginName(), pluginDescriptor.getPluginVersion()));
+    }
+
     @Override
     public void buildFinished(@NotNull SRunningBuild build) {
         if (buildScanDisplayArbiter.showBuildScanInfo(build)) {

--- a/src/main/java/nu/studer/teamcity/buildscan/BuildScanBuildServerListener.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/BuildScanBuildServerListener.java
@@ -32,13 +32,13 @@ public final class BuildScanBuildServerListener extends BuildServerAdapter {
         this.externalIntegration = externalIntegration;
     }
 
-    @SuppressWarnings({"WeakerAccess", "unused"})
+    @SuppressWarnings("unused")
     public void register() {
         buildServer.addListener(this);
-
         LOGGER.info(String.format("Registered %s. %s-%s", getClass().getSimpleName(), pluginDescriptor.getPluginName(), pluginDescriptor.getPluginVersion()));
     }
 
+    @SuppressWarnings("unused")
     public void unregister() {
         buildServer.removeListener(this);
         LOGGER.info(String.format("Unregistered %s. %s-%s", getClass().getSimpleName(), pluginDescriptor.getPluginName(), pluginDescriptor.getPluginVersion()));

--- a/src/main/resources/META-INF/build-server-plugin-buildscans.xml
+++ b/src/main/resources/META-INF/build-server-plugin-buildscans.xml
@@ -5,7 +5,8 @@
        default-autowire="constructor">
 
     <bean id="buildScanViewBuildTab"
-          class="nu.studer.teamcity.buildscan.BuildScanViewBuildTab">
+          class="nu.studer.teamcity.buildscan.BuildScanViewBuildTab"
+          destroy-method="unregister">
     </bean>
 
     <bean id="buildScanBuildServerListener"
@@ -16,7 +17,9 @@
 
     <bean id="buildScanCrumbSummaryExtension"
           class="nu.studer.teamcity.buildscan.BuildScanCrumbSummaryExtension"
-          init-method="register"/>
+          init-method="register"
+          destroy-method="unregister">
+    </bean>
 
     <bean id="cachedBuildScanLookup" primary="true"
           class="nu.studer.teamcity.buildscan.internal.CachedBuildScanLookup"
@@ -47,7 +50,8 @@
 
     <bean id="buildScanAdminPage"
           class="nu.studer.teamcity.buildscan.internal.cleanup.BuildScanAdminPage"
-          init-method="register">
+          init-method="register"
+          destroy-method="unregister">
     </bean>
 
     <bean id="buildScanCleanupController"

--- a/src/main/resources/META-INF/build-server-plugin-buildscans.xml
+++ b/src/main/resources/META-INF/build-server-plugin-buildscans.xml
@@ -10,7 +10,8 @@
 
     <bean id="buildScanBuildServerListener"
           class="nu.studer.teamcity.buildscan.BuildScanBuildServerListener"
-          init-method="register">
+          init-method="register"
+          destroy-method="unregister">
     </bean>
 
     <bean id="buildScanCrumbSummaryExtension"


### PR DESCRIPTION
Unregistering the listener allows the plugin to be unloaded and reloaded. This allows the plugin to be deployed without restarting the TeamCity Server during development and should also allow a released version of the plugin to be upgraded without restarting the server.
