### PR TITLE
Publish configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,9 @@ teamcity {
         }
 
         publish {
-             token = findProperty('jetbrains.token')
-             notes = findProperty('change.notes')
-         }
+            channels = ['Stable']
+            token = findProperty('teamCityPluginPublishToken')
+        }
     }
 
     environments {

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,11 @@ teamcity {
             downloadUrl = 'https://github.com/etiennestuder/teamcity-build-scan-plugin'
             useSeparateClassloader = true
         }
+
+        publish {
+             token = findProperty('jetbrains.token')
+             notes = findProperty('change.notes')
+         }
     }
 
     environments {

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ plugins {
     id 'groovy'
     id 'maven-publish'
     id 'org.nosphere.gradle.github.actions' version '1.2.0'
-    id 'com.github.rodm.teamcity-server' version '1.3.2' // see https://github.com/rodm/gradle-teamcity-plugin
-    id 'com.github.rodm.teamcity-environments' version '1.3.2'
+    id 'com.github.rodm.teamcity-server' version '1.4' // see https://github.com/rodm/gradle-teamcity-plugin
+    id 'com.github.rodm.teamcity-environments' version '1.4'
 }
 
 ext {


### PR DESCRIPTION
This is an example of the configuration supported by the gradle-teamcity-plugin to publish a plugin to the
JetBrains plugin repository.

The section [Publishing a plugin](https://github.com/rodm/gradle-teamcity-plugin#publishing-a-plugin) describes that task and a link to setting up a [token](https://www.jetbrains.com/help/hub/Manage-Permanent-Tokens.html) with JetBrains.

The notes property can be plain text or HTML, I've experimented using the [changelog](https://plugins.gradle.org/plugin/org.jetbrains.changelog) plugin to create HTML from a changelog file in markdown format.
 