### PR TITLE
Output a warning message for unsupported versions of Gradle

### DIFF
--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -2,7 +2,7 @@ import jetbrains.buildServer.messages.serviceMessages.ServiceMessage
 import org.gradle.util.GradleVersion
 
 if (GradleVersion.current() < GradleVersion.version('4.1')) {
-    logger.warn("${GradleVersion.current()} is not supported by the TeamCity Build Scan plugin.")
+    logger.warn("TeamCity Build Scan plugin requires at least Gradle 4.1. Build uses Gradle ${GradleVersion.current()}.")
     return
 }
 

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -2,6 +2,7 @@ import jetbrains.buildServer.messages.serviceMessages.ServiceMessage
 import org.gradle.util.GradleVersion
 
 if (GradleVersion.current() < GradleVersion.version('4.1')) {
+    logger.warn("${GradleVersion.current()} is not supported by the TeamCity Build Scan plugin.")
     return
 }
 


### PR DESCRIPTION
While trying out the plugin in a test environment I didn't realise my test project used an unsupported version of Gradle, this change outputs a warning message to the build log. 