### PR TITLE
Add configurable auto-application of Gradle Enterprise plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ previously downloaded plugin `.zip` file.
 
 1. Find the links of the published build scans in the _Overview_ section of each TeamCity build.
 
+## Automatic Gradle Enterprise Plugin Setup
+
+This functionality currently only works for Gradle version 6 and higher.
+
+1. In TeamCity, on the build configuration for which you want to apply Gradle Enterprise, create a configuration parameter with name `GRADLE_ENTERPRISE_URL` and the value being the URL of the target Gradle Enterprise instance.
+   
+1. Trigger your Gradle build.
+
+1. Find the links of the published build scans in the _Overview_ section of each TeamCity build.
+
+If set, this configuration parameter will set the `gradleEnterprise.server` URL and enable build scan publishing for all builds to which this parameter is set. 
+
+This plugin will apply version 3.10 of the Gradle Enterprise plugin if the `GRADLE_ENTERPRISE_URL` parameter is set and the Gradle Enterprise plugin is not already applied. 
+
 ## Slack Integration
 
 1. In Slack, create a webhook and keep track of the created URL.

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -37,13 +37,44 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
     }
 } else {
     // Gradle 6.+
+    def geUrl = System.getProperty("teamCityBuildScanPlugin.gradle.enterprise.url")
+    def shouldApplyGe = geUrl && !gradle.getParent()
+
+    if (shouldApplyGe) {
+        gradle.beforeSettings { settings ->
+            addGeToClasspath(settings.buildscript)
+        }
+    }
+
     gradle.settingsEvaluated { settings ->
+        if (shouldApplyGe && !settings.pluginManager.hasPlugin("com.gradle.enterprise")) {
+            settings.pluginManager.apply("com.gradle.enterprise")
+        }
+
         extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each {
-            buildScanPublishedAction(settings[it.name].buildScan)
+            buildScanPublishedAction(it.buildScan)
+            configureGeExtension(it, geUrl, shouldApplyGe)
         }
     }
 }
 
+static def addGeToClasspath(def target) {
+    target.repositories { gradlePluginPortal() }
+    target.dependencies.classpath("com.gradle:gradle-enterprise-gradle-plugin:3.10")
+}
+
 static def extensionsWithPublicType(def container, String publicType) {
-    container.extensions.extensionsSchema.elements.findAll { it.publicType.concreteClass.name == publicType }
+    container.extensions.extensionsSchema.elements
+            .findAll { it.publicType.concreteClass.name == publicType }
+            .collect { container[it.name] }
+}
+
+static def configureGeExtension(def gradleEnterprise, def geUrl, def geWasAutoApplied) {
+    gradleEnterprise.server = geUrl ?: gradleEnterprise.server
+
+    if (geWasAutoApplied) {
+        gradleEnterprise.buildScan {
+            publishAlways()
+        }
+    }
 }


### PR DESCRIPTION
This change adds configuration parameters to allow plugin users to
automatically apply and configure the Gradle Enterprise plugin from
TeamCity configuration parameters. `GRADLE_ENTERPRISE_URL` will set the
`gradleEnterprise.server` property and apply the Gradle Enterprise
plugin if not already applied. `GRADLE_ENTERPRISE_VERSION` will
optionally set the version of the applied plugin, defaulting to 3.10.

The change adds 2 system properties to the injected init script to
configure the GE URL and Plugin version, `teamCityBuildScanPlugin.gradle
.enterprise.url` and `teamCityBuildScanPlugin.gradle.enterprise
.pluginVersion` respectively. These are used to pass the configuration
parameters from TeamCity into Gradle.