### PR TITLE
Add configurable auto-application of Gradle Enterprise plugin

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -1,0 +1,24 @@
+name: Verify Build
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Check out project
+                uses: actions/checkout@v2
+            -   name: Set up JDK 6
+                uses: actions/setup-java@v1
+                with:
+                    java-version: '6.0.119'
+                    java-package: jdk
+                    architecture: x64
+            -   name: Set up JDK 8
+                uses: actions/setup-java@v1
+                with:
+                    java-version: '8'
+            -   name: Setup Gradle
+                uses: gradle/gradle-build-action@v2
+            -   name: Build and bundle plugin artifact
+                run: ./gradlew clean build -Porg.gradle.java.installations.fromEnv=JAVA_HOME_6_0_119_X64 -PjavaCompilerVersion=6 -Pteamcity-build-scan-plugin.acceptGradleTOS=true

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -3,7 +3,8 @@ name: Verify Build
 on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
-    build:
+    verification:
+        name: Verification
         runs-on: ubuntu-latest
         steps:
             -   name: Check out project

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -1,8 +1,14 @@
-name: "Build Gradle project"
-on: [ push, workflow_dispatch ]
+name: Create Development Release
+
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
 
 jobs:
-    build:
+    development_release:
+        name: Release
         runs-on: ubuntu-latest
         steps:
             -   name: Check out project

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1,8 +1,16 @@
-name: "Release Gradle project"
-on: [ workflow_dispatch ]
+name: Create Production Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            confirmation:
+                description: Enter the confirmation phrase 'PRODUCTION' (without quotes) if you are sure you want to trigger a release.
+                required: true
 
 jobs:
-    build:
+    production_release:
+        if: github.event.inputs.confirmation == 'PRODUCTION'
+        name: Release
         runs-on: ubuntu-latest
         steps:
             -   name: Check out project

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ previously downloaded plugin `.zip` file.
 
 1. Find the links of the published build scans in the _Overview_ section of each TeamCity build.
 
+## Automatic Gradle Enterprise Plugin Setup
+
+1. In TeamCity, on the build configuration for which you want to apply Gradle Enterprise, create 2 configuration parameters
+
+   - `GRADLE_ENTERPRISE_URL` - the URL of the Gradle Enterprise instance to which you want to publish build scans. If set, this will override the definition of an existing Gradle Enterprise server url.
+   - `GRADLE_ENTERPRISE_PLUGIN_VERSION` - the version of the Gradle Enterprise plugin to apply to the build.
+
+1. Trigger your Gradle build.
+   
+1. Find the links of the published build scans in the _Overview_ section of each TeamCity build.
+
 ## Slack Integration
 
 1. In Slack, create a webhook and keep track of the created URL.

--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ previously downloaded plugin `.zip` file.
 
 ## Automatic Gradle Enterprise Plugin Setup
 
-1. In TeamCity, on the build configuration for which you want to apply Gradle Enterprise, create 2 configuration parameters
+1. In TeamCity, on the build configuration for which you want to apply Gradle Enterprise, create 3 configuration parameters:
 
    - `GRADLE_ENTERPRISE_URL` - the URL of the Gradle Enterprise instance to which you want to publish build scans. If set, this will override the definition of an existing Gradle Enterprise server url.
    - `GRADLE_ENTERPRISE_PLUGIN_VERSION` - the version of the Gradle Enterprise plugin to apply to the build.
+   - `CCUD_PLUGIN_VERSION` - the version of the [Common Custom User Data](https://github.com/gradle/common-custom-user-data-gradle-plugin) plugin to apply to the build.
 
 1. Trigger your Gradle build.
    

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ previously downloaded plugin `.zip` file.
 
 1. In TeamCity, on the build configuration for which you want to apply Gradle Enterprise, create 3 configuration parameters:
 
-   - `GRADLE_ENTERPRISE_URL` - the URL of the Gradle Enterprise instance to which you want to publish build scans. If a URL is already configured, this parameter will not be used.
+   - `GRADLE_ENTERPRISE_URL` - the URL of the Gradle Enterprise instance to which you want to publish build scans.
    - `GRADLE_ENTERPRISE_PLUGIN_VERSION` - the version of the Gradle Enterprise plugin to apply to the build.
    - `CCUD_PLUGIN_VERSION` - the version of the [Common Custom User Data](https://github.com/gradle/common-custom-user-data-gradle-plugin) plugin to apply to the build.
 
 1. Trigger your Gradle build.
-   
+
 1. Find the links of the published build scans in the _Overview_ section of each TeamCity build.
 
 ## Slack Integration

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ previously downloaded plugin `.zip` file.
 
 1. In TeamCity, on the build configuration for which you want to apply Gradle Enterprise, create 3 configuration parameters:
 
-   - `GRADLE_ENTERPRISE_URL` - the URL of the Gradle Enterprise instance to which you want to publish build scans. If set, this will override the definition of an existing Gradle Enterprise server url.
+   - `GRADLE_ENTERPRISE_URL` - the URL of the Gradle Enterprise instance to which you want to publish build scans. If a URL is already configured, this parameter will not be used.
    - `GRADLE_ENTERPRISE_PLUGIN_VERSION` - the version of the Gradle Enterprise plugin to apply to the build.
    - `CCUD_PLUGIN_VERSION` - the version of the [Common Custom User Data](https://github.com/gradle/common-custom-user-data-gradle-plugin) plugin to apply to the build.
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -38,7 +38,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GE_PLUGIN_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle.enterprise.plugin.version";
 
-    private static final String CCUD_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.ccud.plugin.version";
+    private static final String CCUD_PLUGIN_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.ccud.plugin.version";
 
     public BuildScanServiceMessageInjector(@NotNull EventDispatcher<AgentLifeCycleListener> eventDispatcher) {
         eventDispatcher.addListener(this);
@@ -49,7 +49,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         if (runner.getRunType().equalsIgnoreCase(GRADLE_RUNNER)) {
             addGradleSysPropIfSet(GRADLE_ENTERPRISE_URL_CONFIG_PARAM, GE_URL_GRADLE_PROPERTY, runner);
             addGradleSysPropIfSet(GRADLE_ENTERPRISE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_GRADLE_PROPERTY, runner);
-            addGradleSysPropIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_VERSION_GRADLE_PROPERTY, runner);
+            addGradleSysPropIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_PLUGIN_VERSION_GRADLE_PROPERTY, runner);
 
             String initScriptParam = "--init-script " + getInitScript(runner).getAbsolutePath();
             addGradleCmdParam(initScriptParam, runner);

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -28,17 +28,17 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GRADLE_BUILDSCAN_TEAMCITY_PLUGIN = "GRADLE_BUILDSCAN_TEAMCITY_PLUGIN";
 
-    private static final String GRADLE_ENTERPRISE_URL_PARAMETER = "GRADLE_ENTERPRISE_URL";
+    private static final String GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "GRADLE_ENTERPRISE_URL";
 
-    private static final String GRADLE_ENTERPRISE_PLUGIN_VERSION_PARAMETER = "GRADLE_ENTERPRISE_PLUGIN_VERSION";
+    private static final String GRADLE_ENTERPRISE_PLUGIN_VERSION_CONFIG_PARAM = "GRADLE_ENTERPRISE_PLUGIN_VERSION";
 
-    private static final String CCUD_PLUGIN_VERSION_PARAMETER = "CCUD_PLUGIN_VERSION";
+    private static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "CCUD_PLUGIN_VERSION";
 
     private static final String GE_URL_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle.enterprise.url";
 
-    private static final String GE_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle.enterprise.plugin.version";
+    private static final String GE_PLUGIN_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle.enterprise.plugin.version";
 
-    private static final String CCUD_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.ccud.version";
+    private static final String CCUD_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.ccud.plugin.version";
 
     public BuildScanServiceMessageInjector(@NotNull EventDispatcher<AgentLifeCycleListener> eventDispatcher) {
         eventDispatcher.addListener(this);
@@ -47,9 +47,9 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
     @Override
     public void beforeRunnerStart(@NotNull BuildRunnerContext runner) {
         if (runner.getRunType().equalsIgnoreCase(GRADLE_RUNNER)) {
-            addGradleSysPropIfSet(GRADLE_ENTERPRISE_URL_PARAMETER, GE_URL_GRADLE_PROPERTY, runner);
-            addGradleSysPropIfSet(GRADLE_ENTERPRISE_PLUGIN_VERSION_PARAMETER, GE_VERSION_GRADLE_PROPERTY, runner);
-            addGradleSysPropIfSet(CCUD_PLUGIN_VERSION_PARAMETER, CCUD_VERSION_GRADLE_PROPERTY, runner);
+            addGradleSysPropIfSet(GRADLE_ENTERPRISE_URL_CONFIG_PARAM, GE_URL_GRADLE_PROPERTY, runner);
+            addGradleSysPropIfSet(GRADLE_ENTERPRISE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_GRADLE_PROPERTY, runner);
+            addGradleSysPropIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_VERSION_GRADLE_PROPERTY, runner);
 
             String initScriptParam = "--init-script " + getInitScript(runner).getAbsolutePath();
             addGradleCmdParam(initScriptParam, runner);
@@ -81,16 +81,6 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         return runnerParameters.containsKey(paramName) ? runnerParameters.get(paramName) : "";
     }
 
-    @Nullable
-    private static String getOptionalConfigParam(@NotNull BuildRunnerContext runner, @NotNull String paramName) {
-        if (!runner.getConfigParameters().containsKey(paramName)) {
-            return null;
-        }
-
-        String value = runner.getConfigParameters().get(paramName).trim();
-        return value.isEmpty() ? null : value;
-    }
-
     private static void addGradleSysPropIfSet(@NotNull String configParameter, @NotNull String gradleProperty, @NotNull BuildRunnerContext runner) {
         String value = getOptionalConfigParam(runner, configParameter);
         if (value != null) {
@@ -108,4 +98,14 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         runner.addRunnerParameter(GRADLE_CMD_PARAMS, param + " " + existingParams);
     }
 
+    @Nullable
+    private static String getOptionalConfigParam(@NotNull BuildRunnerContext runner, @NotNull String paramName) {
+        Map<String, String> configParameters = runner.getConfigParameters();
+        if (!configParameters.containsKey(paramName)) {
+            return null;
+        }
+
+        String value = configParameters.get(paramName).trim();
+        return value.isEmpty() ? null : value;
+    }
 }

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -75,12 +75,6 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         return extensionJar;
     }
 
-    @SuppressWarnings("Java8MapApi") // support JDK6
-    private static String getOrDefault(@NotNull String paramName, @NotNull BuildRunnerContext runner) {
-        Map<String, String> runnerParameters = runner.getRunnerParameters();
-        return runnerParameters.containsKey(paramName) ? runnerParameters.get(paramName) : "";
-    }
-
     private static void addGradleSysPropIfSet(@NotNull String configParameter, @NotNull String gradleProperty, @NotNull BuildRunnerContext runner) {
         String value = getOptionalConfigParam(runner, configParameter);
         if (value != null) {
@@ -108,4 +102,11 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         String value = configParameters.get(paramName).trim();
         return value.isEmpty() ? null : value;
     }
+
+    @SuppressWarnings("Java8MapApi") // support JDK6
+    private static String getOrDefault(@NotNull String paramName, @NotNull BuildRunnerContext runner) {
+        Map<String, String> runnerParameters = runner.getRunnerParameters();
+        return runnerParameters.containsKey(paramName) ? runnerParameters.get(paramName) : "";
+    }
+
 }

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -34,7 +34,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "CCUD_PLUGIN_VERSION";
 
-    private static final String GE_URL_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle.enterprise.url";
+    private static final String GE_URL_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle-enterprise.url";
 
     private static final String GE_PLUGIN_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle-enterprise.plugin.version";
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -28,9 +28,9 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GRADLE_BUILDSCAN_TEAMCITY_PLUGIN = "GRADLE_BUILDSCAN_TEAMCITY_PLUGIN";
 
-    private static final String GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "GRADLE_ENTERPRISE_URL";
+    private static final String GE_URL_CONFIG_PARAM = "GRADLE_ENTERPRISE_URL";
 
-    private static final String GRADLE_ENTERPRISE_PLUGIN_VERSION_CONFIG_PARAM = "GRADLE_ENTERPRISE_PLUGIN_VERSION";
+    private static final String GE_PLUGIN_VERSION_CONFIG_PARAM = "GRADLE_ENTERPRISE_PLUGIN_VERSION";
 
     private static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "CCUD_PLUGIN_VERSION";
 
@@ -47,8 +47,8 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
     @Override
     public void beforeRunnerStart(@NotNull BuildRunnerContext runner) {
         if (runner.getRunType().equalsIgnoreCase(GRADLE_RUNNER)) {
-            addGradleSysPropIfSet(GRADLE_ENTERPRISE_URL_CONFIG_PARAM, GE_URL_GRADLE_PROPERTY, runner);
-            addGradleSysPropIfSet(GRADLE_ENTERPRISE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_GRADLE_PROPERTY, runner);
+            addGradleSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_GRADLE_PROPERTY, runner);
+            addGradleSysPropIfSet(GE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_GRADLE_PROPERTY, runner);
             addGradleSysPropIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_PLUGIN_VERSION_GRADLE_PROPERTY, runner);
 
             String initScriptParam = "--init-script " + getInitScript(runner).getAbsolutePath();

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -32,9 +32,13 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GRADLE_ENTERPRISE_PLUGIN_VERSION_PARAMETER = "GRADLE_ENTERPRISE_PLUGIN_VERSION";
 
+    private static final String CCUD_PLUGIN_VERSION_PARAMETER = "CCUD_PLUGIN_VERSION";
+
     private static final String GE_URL_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle.enterprise.url";
 
     private static final String GE_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle.enterprise.plugin.version";
+
+    private static final String CCUD_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.ccud.version";
 
     public BuildScanServiceMessageInjector(@NotNull EventDispatcher<AgentLifeCycleListener> eventDispatcher) {
         eventDispatcher.addListener(this);
@@ -45,6 +49,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         if (runner.getRunType().equalsIgnoreCase(GRADLE_RUNNER)) {
             addGradleSysPropIfSet(GRADLE_ENTERPRISE_URL_PARAMETER, GE_URL_GRADLE_PROPERTY, runner);
             addGradleSysPropIfSet(GRADLE_ENTERPRISE_PLUGIN_VERSION_PARAMETER, GE_VERSION_GRADLE_PROPERTY, runner);
+            addGradleSysPropIfSet(CCUD_PLUGIN_VERSION_PARAMETER, CCUD_VERSION_GRADLE_PROPERTY, runner);
 
             String initScriptParam = "--init-script " + getInitScript(runner).getAbsolutePath();
             addGradleCmdParam(initScriptParam, runner);

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -56,10 +56,8 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
             addEnvVar(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN, "1", runner);
         } else if (runner.getRunType().equalsIgnoreCase(MAVEN_RUNNER)) {
-            String existingParams = getOrDefault(MAVEN_CMD_PARAMS, runner);
             String extJarParam = "-Dmaven.ext.class.path=" + getExtensionJar(runner).getAbsolutePath();
-
-            runner.addRunnerParameter(MAVEN_CMD_PARAMS, extJarParam + " " + existingParams);
+            addMavenCmdParam(extJarParam, runner);
 
             addEnvVar(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN, "1", runner);
         }
@@ -97,6 +95,11 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
     private static void addGradleCmdParam(@NotNull String param, @NotNull BuildRunnerContext runner) {
         String existingParams = getOrDefault(GRADLE_CMD_PARAMS, runner);
         runner.addRunnerParameter(GRADLE_CMD_PARAMS, param + " " + existingParams);
+    }
+
+    private static void addMavenCmdParam(@NotNull String param, @NotNull BuildRunnerContext runner) {
+        String existingParams = getOrDefault(MAVEN_CMD_PARAMS, runner);
+        runner.addRunnerParameter(MAVEN_CMD_PARAMS, param + " " + existingParams);
     }
 
     @Nullable

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -36,7 +36,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GE_URL_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle.enterprise.url";
 
-    private static final String GE_PLUGIN_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle.enterprise.plugin.version";
+    private static final String GE_PLUGIN_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.gradle-enterprise.plugin.version";
 
     private static final String CCUD_PLUGIN_VERSION_GRADLE_PROPERTY = "teamCityBuildScanPlugin.ccud.plugin.version";
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -53,13 +53,15 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
             String initScriptParam = "--init-script " + getInitScript(runner).getAbsolutePath();
             addGradleCmdParam(initScriptParam, runner);
-            runner.addEnvironmentVariable(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN, "1");
+
+            addEnvVar(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN, "1", runner);
         } else if (runner.getRunType().equalsIgnoreCase(MAVEN_RUNNER)) {
             String existingParams = getOrDefault(MAVEN_CMD_PARAMS, runner);
             String extJarParam = "-Dmaven.ext.class.path=" + getExtensionJar(runner).getAbsolutePath();
 
             runner.addRunnerParameter(MAVEN_CMD_PARAMS, extJarParam + " " + existingParams);
-            runner.addEnvironmentVariable(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN, "1");
+
+            addEnvVar(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN, "1", runner);
         }
     }
 
@@ -73,6 +75,11 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         File extensionJar = new File(runner.getBuild().getAgentTempDirectory(), BUILD_SCAN_EXT_MAVEN);
         FileUtil.copyResourceIfNotExists(BuildScanServiceMessageInjector.class, "/" + BUILD_SCAN_EXT_MAVEN, extensionJar);
         return extensionJar;
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void addEnvVar(@NotNull String key, @NotNull String value, @NotNull BuildRunnerContext runner) {
+        runner.addEnvironmentVariable(key, value);
     }
 
     private static void addGradleSysPropIfSet(@NotNull String configParameter, @NotNull String gradleProperty, @NotNull BuildRunnerContext runner) {

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -6,21 +6,21 @@ if (GradleVersion.current() < GradleVersion.version('4.1')) {
 }
 
 initscript {
-    def geVersion = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version')
+    def gePluginVersion = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version')
+    def ccudPluginVersion = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version')
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
-    def ccudVersion = System.getProperty('teamCityBuildScanPlugin.ccud.version')
 
-    if (geVersion && !gradle.getParent()) {
+    if (gePluginVersion && !gradle.getParent()) {
         repositories {
             maven { url 'https://plugins.gradle.org/m2' }
         }
         dependencies {
             classpath atLeastGradle5 ?
-                    "com.gradle:gradle-enterprise-gradle-plugin:$geVersion" :
-                    "com.gradle:build-scan-plugin:$geVersion"
+                    "com.gradle:gradle-enterprise-gradle-plugin:$gePluginVersion" :
+                    "com.gradle:build-scan-plugin:$gePluginVersion"
 
-            if (atLeastGradle5 && ccudVersion) {
-                classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudVersion"
+            if (atLeastGradle5 && ccudPluginVersion) {
+                classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
             }
         }
     }
@@ -39,8 +39,8 @@ def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleE
 def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
 
 def geUrl = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.url')
-def autoApplyGe = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version') && !gradle.getParent()
-def autoApplyCcud = System.getProperty('teamCityBuildScanPlugin.ccud.version') && GradleVersion.current() >= GradleVersion.version('5.0')
+def autoApplyGePlugin = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version') && !gradle.getParent()
+def autoApplyCcudPlugin = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version') && GradleVersion.current() >= GradleVersion.version('5.0')
 
 def buildScanPublishedAction = { def buildScan ->
     if (buildScan.metaClass.respondsTo(buildScan, 'buildScanPublished', Action)) {
@@ -53,11 +53,11 @@ def buildScanPublishedAction = { def buildScan ->
 if (GradleVersion.current() < GradleVersion.version('6.0')) {
     // Gradle 4.1+ and 5.+
     rootProject {
-        if (autoApplyGe && !pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) {
+        if (autoApplyGePlugin && !pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) {
             pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
         }
 
-        if (autoApplyCcud && !pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+        if (autoApplyCcudPlugin && !pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
             pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
         }
 
@@ -66,7 +66,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             buildScan {
                 afterEvaluate {
                     server = geUrl ?: server
-                    publishAlwaysIf(autoApplyGe)
+                    publishAlwaysIf(autoApplyGePlugin)
                 }
             }
         }
@@ -74,11 +74,11 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 } else {
     // Gradle 6.+
     gradle.settingsEvaluated { settings ->
-        if (autoApplyGe && !settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
+        if (autoApplyGePlugin && !settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
             settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
         }
 
-        if (autoApplyCcud && !settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+        if (autoApplyCcudPlugin && !settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
             settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
         }
 
@@ -86,7 +86,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             buildScanPublishedAction(ext.buildScan)
             ext.server = geUrl ?: ext.server
             ext.buildScan {
-                publishAlwaysIf(autoApplyGe)
+                publishAlwaysIf(autoApplyGePlugin)
             }
         }
     }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -9,19 +9,25 @@ initscript {
     def gePluginVersion = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version')
     def ccudPluginVersion = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version')
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+    def isTopLevelBuild = !gradle.parent
+    def addGePluginToClasspath = gePluginVersion && isTopLevelBuild
+    def addCcudPluginToClasspath = ccudPluginVersion && atLeastGradle5 && isTopLevelBuild
 
-    if (gePluginVersion && !gradle.getParent()) {
+    if (addGePluginToClasspath || addCcudPluginToClasspath) {
         repositories {
             maven { url 'https://plugins.gradle.org/m2' }
         }
-        dependencies {
+    }
+
+    dependencies {
+        if (addGePluginToClasspath) {
             classpath atLeastGradle5 ?
                     "com.gradle:gradle-enterprise-gradle-plugin:$gePluginVersion" :
                     "com.gradle:build-scan-plugin:$gePluginVersion"
+        }
 
-            if (atLeastGradle5 && ccudPluginVersion) {
-                classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
-            }
+        if (addCcudPluginToClasspath) {
+            classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
         }
     }
 }
@@ -38,9 +44,11 @@ def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
 def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
 def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
 
+def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+def isTopLevelBuild = !gradle.parent
 def geUrl = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.url')
-def autoApplyGePlugin = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version') && !gradle.getParent()
-def autoApplyCcudPlugin = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version') && GradleVersion.current() >= GradleVersion.version('5.0')
+def autoApplyGePlugin = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version') && isTopLevelBuild
+def autoApplyCcudPlugin = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version') && isTopLevelBuild && atLeastGradle5
 
 def buildScanPublishedAction = { def buildScan ->
     if (buildScan.metaClass.respondsTo(buildScan, 'buildScanPublished', Action)) {
@@ -55,6 +63,13 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
     rootProject {
         if (autoApplyGePlugin && !pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) {
             pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
+
+            pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                buildScan {
+                    server = geUrl
+                    publishAlways()
+                }
+            }
         }
 
         if (autoApplyCcudPlugin && !pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
@@ -63,10 +78,6 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
         pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
             buildScanPublishedAction(buildScan)
-            buildScan {
-                server = geUrl
-                publishAlwaysIf(autoApplyGePlugin)
-            }
         }
     }
 } else {
@@ -74,6 +85,13 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
     gradle.settingsEvaluated { settings ->
         if (autoApplyGePlugin && !settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
             settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
+
+            extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each { ext ->
+                ext.server = ext.server ?: geUrl
+                ext.buildScan {
+                    publishAlways()
+                }
+            }
         }
 
         if (autoApplyCcudPlugin && !settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
@@ -82,10 +100,6 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
         extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each { ext ->
             buildScanPublishedAction(ext.buildScan)
-            ext.server = ext.server ?: geUrl
-            ext.buildScan {
-                publishAlwaysIf(autoApplyGePlugin)
-            }
         }
     }
 }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -5,10 +5,31 @@ if (GradleVersion.current() < GradleVersion.version('4.1')) {
     return
 }
 
+initscript {
+    def geVersion = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version')
+    if (geVersion && !gradle.getParent()) {
+        repositories {
+            maven { url 'https://plugins.gradle.org/m2' }
+        }
+        dependencies {
+            classpath GradleVersion.current() >= GradleVersion.version('5.0') ?
+                    "com.gradle:gradle-enterprise-gradle-plugin:$geVersion" :
+                    "com.gradle:build-scan-plugin:$geVersion"
+        }
+    }
+}
+
 logger.quiet(generateBuildScanLifeCycleMessage('BUILD_STARTED'))
 
 def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
+
+def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
 def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
+
+def geUrl = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.url')
+def autoApplyGe = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version') && !gradle.getParent()
 
 def buildScanPublishedAction = { def buildScan ->
     if (buildScan.metaClass.respondsTo(buildScan, 'buildScanPublished', Action)) {
@@ -21,21 +42,41 @@ def buildScanPublishedAction = { def buildScan ->
 if (GradleVersion.current() < GradleVersion.version('6.0')) {
     // Gradle 4.1+ and 5.+
     rootProject {
+        if (autoApplyGe && !pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) {
+            pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
+        }
+
         pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
             buildScanPublishedAction(buildScan)
+            buildScan {
+                afterEvaluate {
+                    server = geUrl ?: server
+                    publishAlwaysIf(autoApplyGe)
+                }
+            }
         }
     }
 } else {
     // Gradle 6.+
     gradle.settingsEvaluated { settings ->
-        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each {
-            buildScanPublishedAction(settings[it.name].buildScan)
+        if (autoApplyGe && !settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
+            settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
+        }
+
+        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each { ext ->
+            buildScanPublishedAction(ext.buildScan)
+            ext.server = geUrl ?: ext.server
+            ext.buildScan {
+                publishAlwaysIf(autoApplyGe)
+            }
         }
     }
 }
 
 static def extensionsWithPublicType(def container, String publicType) {
-    container.extensions.extensionsSchema.elements.findAll { it.publicType.concreteClass.name == publicType }
+    container.extensions.extensionsSchema.elements
+            .findAll { it.publicType.concreteClass.name == publicType }
+            .collect { container[it.name] }
 }
 
 static String generateBuildScanLifeCycleMessage(def attribute) {

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -6,27 +6,29 @@ if (GradleVersion.current() < GradleVersion.version('4.1')) {
 }
 
 initscript {
+    def isTopLevelBuild = !gradle.parent
+    def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def gePluginVersion = System.getProperty('teamCityBuildScanPlugin.gradle-enterprise.plugin.version')
     def ccudPluginVersion = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version')
-    def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
-    def isTopLevelBuild = !gradle.parent
-    def addGePluginToClasspath = gePluginVersion && isTopLevelBuild
-    def addCcudPluginToClasspath = ccudPluginVersion && atLeastGradle5 && isTopLevelBuild
 
-    if (addGePluginToClasspath || addCcudPluginToClasspath) {
+    if (!isTopLevelBuild) {
+        return
+    }
+
+    if (gePluginVersion || ccudPluginVersion && atLeastGradle5) {
         repositories {
             maven { url 'https://plugins.gradle.org/m2' }
         }
     }
 
     dependencies {
-        if (addGePluginToClasspath) {
+        if (gePluginVersion) {
             classpath atLeastGradle5 ?
-                    "com.gradle:gradle-enterprise-gradle-plugin:$gePluginVersion" :
-                    "com.gradle:build-scan-plugin:$gePluginVersion"
+                "com.gradle:gradle-enterprise-gradle-plugin:$gePluginVersion" :
+                "com.gradle:build-scan-plugin:1.16"
         }
 
-        if (addCcudPluginToClasspath) {
+        if (ccudPluginVersion && atLeastGradle5) {
             classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
         }
     }
@@ -86,7 +88,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         if (autoApplyGePlugin && !settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
             settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
 
-            extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect{ settings[it.name] }.each { ext ->
+            extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
                 ext.server = ext.server ?: geUrl
                 ext.buildScan {
                     publishAlways()
@@ -113,7 +115,7 @@ static String generateBuildScanLifeCycleMessage(def attribute) {
 }
 
 static String escape(String value) {
-    return value?.toCharArray()?.collect{ch -> escapeChar(ch) }?.join()
+    return value?.toCharArray()?.collect { ch -> escapeChar(ch) }?.join()
 }
 
 static String escapeChar(char ch) {
@@ -125,6 +127,6 @@ static String escapeChar(char ch) {
         case '\'': return escapeCharacter + "\'"
         case '[': return escapeCharacter + "["
         case ']': return escapeCharacter + "]"
-        default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int)ch)
+        default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int) ch)
     }
 }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -91,7 +91,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
                 pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                     buildScan {
-                        server = server ?: geUrl
+                        server = geUrl
                         publishAlways()
                     }
                 }
@@ -111,7 +111,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
 
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
-                    ext.server = ext.server ?: geUrl
+                    ext.server = geUrl
                     ext.buildScan {
                         publishAlways()
                     }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -46,7 +46,7 @@ def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.Grad
 
 def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
 def isTopLevelBuild = !gradle.parent
-def geUrl = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.url')
+def geUrl = System.getProperty('teamCityBuildScanPlugin.gradle-enterprise.url')
 def autoApplyGePlugin = System.getProperty('teamCityBuildScanPlugin.gradle-enterprise.plugin.version') && isTopLevelBuild
 def autoApplyCcudPlugin = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version') && isTopLevelBuild && atLeastGradle5
 

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -86,7 +86,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         if (autoApplyGePlugin && !settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
             settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
 
-            extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each { ext ->
+            extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect{ settings[it.name] }.each { ext ->
                 ext.server = ext.server ?: geUrl
                 ext.buildScan {
                     publishAlways()
@@ -98,16 +98,14 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
         }
 
-        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each { ext ->
-            buildScanPublishedAction(ext.buildScan)
+        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each {
+            buildScanPublishedAction(settings[it.name].buildScan)
         }
     }
 }
 
 static def extensionsWithPublicType(def container, String publicType) {
-    container.extensions.extensionsSchema.elements
-            .findAll { it.publicType.concreteClass.name == publicType }
-            .collect { container[it.name] }
+    container.extensions.extensionsSchema.elements.findAll { it.publicType.concreteClass.name == publicType }
 }
 
 static String generateBuildScanLifeCycleMessage(def attribute) {

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -72,8 +72,8 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
     }
 } else {
     gradle.settingsEvaluated { settings ->
-        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each {
-            buildScanPublishedAction(settings[it.name].buildScan)
+        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
+            buildScanPublishedAction(ext.buildScan)
         }
     }
 }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -91,7 +91,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
                 pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                     buildScan {
-                        server = geUrl
+                        server = server ?: geUrl
                         publishAlways()
                     }
                 }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -7,14 +7,21 @@ if (GradleVersion.current() < GradleVersion.version('4.1')) {
 
 initscript {
     def geVersion = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version')
+    def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+    def ccudVersion = System.getProperty('teamCityBuildScanPlugin.ccud.version')
+
     if (geVersion && !gradle.getParent()) {
         repositories {
             maven { url 'https://plugins.gradle.org/m2' }
         }
         dependencies {
-            classpath GradleVersion.current() >= GradleVersion.version('5.0') ?
+            classpath atLeastGradle5 ?
                     "com.gradle:gradle-enterprise-gradle-plugin:$geVersion" :
                     "com.gradle:build-scan-plugin:$geVersion"
+
+            if (atLeastGradle5 && ccudVersion) {
+                classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudVersion"
+            }
         }
     }
 }
@@ -24,12 +31,16 @@ logger.quiet(generateBuildScanLifeCycleMessage('BUILD_STARTED'))
 def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
 def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
+def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
+def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+
 def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
 def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
 def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
 
 def geUrl = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.url')
 def autoApplyGe = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version') && !gradle.getParent()
+def autoApplyCcud = System.getProperty('teamCityBuildScanPlugin.ccud.version') && GradleVersion.current() >= GradleVersion.version('5.0')
 
 def buildScanPublishedAction = { def buildScan ->
     if (buildScan.metaClass.respondsTo(buildScan, 'buildScanPublished', Action)) {
@@ -44,6 +55,10 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
     rootProject {
         if (autoApplyGe && !pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) {
             pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
+        }
+
+        if (autoApplyCcud && !pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+            pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
         }
 
         pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
@@ -61,6 +76,10 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
     gradle.settingsEvaluated { settings ->
         if (autoApplyGe && !settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
             settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
+        }
+
+        if (autoApplyCcud && !settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+            settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
         }
 
         extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each { ext ->

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -1,10 +1,12 @@
 import org.gradle.util.GradleVersion
 
+// finish early if the build is not run with the minimum supported Gradle version
 if (GradleVersion.current() < GradleVersion.version('4.1')) {
     logger.warn("TeamCity Build Scan plugin requires at least Gradle 4.1. Build uses Gradle ${GradleVersion.current()}.")
     return
 }
 
+// conditionally apply the GE / Build Scan plugin to the classpath so it can be applied to the build further down in this script
 initscript {
     def isTopLevelBuild = !gradle.parent
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
@@ -34,24 +36,26 @@ initscript {
     }
 }
 
+// send a message to the server that the build has started
 logger.quiet(generateBuildScanLifeCycleMessage('BUILD_STARTED'))
 
 def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
 def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
-def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
-def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
-
 def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
 def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
 def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
 
-def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
-def isTopLevelBuild = !gradle.parent
-def geUrl = System.getProperty('teamCityBuildScanPlugin.gradle-enterprise.url')
-def autoApplyGePlugin = System.getProperty('teamCityBuildScanPlugin.gradle-enterprise.plugin.version') && isTopLevelBuild
-def autoApplyCcudPlugin = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version') && isTopLevelBuild && atLeastGradle5
+def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
+def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
 
+def isTopLevelBuild = !gradle.parent
+def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+def geUrl = System.getProperty('teamCityBuildScanPlugin.gradle-enterprise.url')
+def gePluginVersion = System.getProperty('teamCityBuildScanPlugin.gradle-enterprise.plugin.version')
+def ccudPluginVersion = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version')
+
+// add a buildScanPublished listener that captures the build scan URL and sends it in a message to the server
 def buildScanPublishedAction = { def buildScan ->
     if (buildScan.metaClass.respondsTo(buildScan, 'buildScanPublished', Action)) {
         buildScan.buildScanPublished { scan ->
@@ -61,9 +65,27 @@ def buildScanPublishedAction = { def buildScan ->
 }
 
 if (GradleVersion.current() < GradleVersion.version('6.0')) {
-    // Gradle 4.1+ and 5.+
     rootProject {
-        if (autoApplyGePlugin && !pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) {
+        pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+            buildScanPublishedAction(buildScan)
+        }
+    }
+} else {
+    gradle.settingsEvaluated { settings ->
+        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each {
+            buildScanPublishedAction(settings[it.name].buildScan)
+        }
+    }
+}
+
+if (!isTopLevelBuild) {
+    return
+}
+
+// conditionally apply the GE / Build Scan plugin to the classpath
+if (GradleVersion.current() < GradleVersion.version('6.0')) {
+    rootProject {
+        if (!pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID) && gePluginVersion) {
             pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
 
             pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
@@ -74,18 +96,13 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             }
         }
 
-        if (autoApplyCcudPlugin && !pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+        if (!pluginManager.hasPlugin(CCUD_PLUGIN_ID) && ccudPluginVersion && atLeastGradle5) {
             pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
-        }
-
-        pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-            buildScanPublishedAction(buildScan)
         }
     }
 } else {
-    // Gradle 6.+
     gradle.settingsEvaluated { settings ->
-        if (autoApplyGePlugin && !settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
+        if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && gePluginVersion) {
             settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
 
             extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
@@ -96,12 +113,8 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             }
         }
 
-        if (autoApplyCcudPlugin && !settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+        if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID) && ccudPluginVersion && atLeastGradle5) {
             settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
-        }
-
-        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each {
-            buildScanPublishedAction(settings[it.name].buildScan)
         }
     }
 }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -78,43 +78,51 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
     }
 }
 
+// conditionally apply the GE / Build Scan plugin to the classpath
 if (!isTopLevelBuild) {
     return
 }
 
-// conditionally apply the GE / Build Scan plugin to the classpath
 if (GradleVersion.current() < GradleVersion.version('6.0')) {
     rootProject {
-        if (!pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID) && gePluginVersion) {
-            pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
+        if (gePluginVersion) {
+            if (!pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) {
+                pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
 
-            pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                buildScan {
-                    server = geUrl
-                    publishAlways()
+                pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                    buildScan {
+                        server = geUrl
+                        publishAlways()
+                    }
                 }
             }
         }
 
-        if (!pluginManager.hasPlugin(CCUD_PLUGIN_ID) && ccudPluginVersion && atLeastGradle5) {
-            pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+        if (ccudPluginVersion && atLeastGradle5) {
+            if (!pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+                pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+            }
         }
     }
 } else {
     gradle.settingsEvaluated { settings ->
-        if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && gePluginVersion) {
-            settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
+        if (gePluginVersion) {
+            if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
+                settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
 
-            extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
-                ext.server = ext.server ?: geUrl
-                ext.buildScan {
-                    publishAlways()
+                extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
+                    ext.server = ext.server ?: geUrl
+                    ext.buildScan {
+                        publishAlways()
+                    }
                 }
             }
         }
 
-        if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID) && ccudPluginVersion && atLeastGradle5) {
-            settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+        if (ccudPluginVersion && atLeastGradle5) {
+            if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+                settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+            }
         }
     }
 }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -6,7 +6,7 @@ if (GradleVersion.current() < GradleVersion.version('4.1')) {
 }
 
 initscript {
-    def gePluginVersion = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version')
+    def gePluginVersion = System.getProperty('teamCityBuildScanPlugin.gradle-enterprise.plugin.version')
     def ccudPluginVersion = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version')
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def isTopLevelBuild = !gradle.parent
@@ -47,7 +47,7 @@ def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.Grad
 def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
 def isTopLevelBuild = !gradle.parent
 def geUrl = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.url')
-def autoApplyGePlugin = System.getProperty('teamCityBuildScanPlugin.gradle.enterprise.plugin.version') && isTopLevelBuild
+def autoApplyGePlugin = System.getProperty('teamCityBuildScanPlugin.gradle-enterprise.plugin.version') && isTopLevelBuild
 def autoApplyCcudPlugin = System.getProperty('teamCityBuildScanPlugin.ccud.plugin.version') && isTopLevelBuild && atLeastGradle5
 
 def buildScanPublishedAction = { def buildScan ->
@@ -119,12 +119,12 @@ static String escape(String value) {
 static String escapeChar(char ch) {
     String escapeCharacter = "|"
     switch (ch) {
-        case '\n': return escapeCharacter + "n";
-        case '\r': return escapeCharacter + "r";
-        case '|': return escapeCharacter + "|";
-        case '\'': return escapeCharacter + "\'";
-        case '[': return escapeCharacter + "[";
-        case ']': return escapeCharacter + "]";
-        default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int)ch);
+        case '\n': return escapeCharacter + "n"
+        case '\r': return escapeCharacter + "r"
+        case '|': return escapeCharacter + "|"
+        case '\'': return escapeCharacter + "\'"
+        case '[': return escapeCharacter + "["
+        case ']': return escapeCharacter + "]"
+        default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int)ch)
     }
 }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -64,10 +64,8 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
             buildScanPublishedAction(buildScan)
             buildScan {
-                afterEvaluate {
-                    server = geUrl ?: server
-                    publishAlwaysIf(autoApplyGePlugin)
-                }
+                server = geUrl
+                publishAlwaysIf(autoApplyGePlugin)
             }
         }
     }
@@ -84,7 +82,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
         extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).each { ext ->
             buildScanPublishedAction(ext.buildScan)
-            ext.server = geUrl ?: ext.server
+            ext.server = ext.server ?: geUrl
             ext.buildScan {
                 publishAlwaysIf(autoApplyGePlugin)
             }


### PR DESCRIPTION
This change adds configuration parameters to allow plugin users to
automatically apply and configure the Gradle Enterprise plugin from
TeamCity configuration parameters. `GRADLE_ENTERPRISE_URL` will set the
`gradleEnterprise.server` property. `GRADLE_ENTERPRISE_PLUGIN_VERSION`
will apply the specified version of the Gradle Enterprise plugin if not
already applied.

The change adds the `teamCityBuildScanPlugin.gradle.enterprise.url` and
`teamCityBuildScanPlugin.gradle.enterprise.plugin.version`
system properties to the injected init script in order to pass the
configuration parameters from TeamCity into Gradle.

Support for the CCUD Gradle plugin has been added, too.