### PR TITLE
Add TC config property to set allowUntrustedServer

### DIFF
--- a/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
+++ b/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
@@ -33,6 +33,12 @@ public final class BuildScanServiceMessageMavenExtension implements GradleEnterp
             BuildScanServiceMessageSender.register(api.getBuildScan());
             logger.debug("Finished registering listener capturing build scan link");
         }
+
+        // The GE Maven extension does not provide a system property to configure 'allowUntrustedServer', so we apply the TC config parameter via the GE API.
+        if (Boolean.parseBoolean(System.getenv("TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER"))) {
+            logger.info("Allowing untrusted Gradle Enterprise server via Maven extension");
+            api.setAllowUntrustedServer(true);
+        }
     }
 
     private static boolean invokesJetBrainsInfoGoal(MavenSession session) {

--- a/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
+++ b/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
@@ -33,12 +33,6 @@ public final class BuildScanServiceMessageMavenExtension implements GradleEnterp
             BuildScanServiceMessageSender.register(api.getBuildScan());
             logger.debug("Finished registering listener capturing build scan link");
         }
-
-        // The GE Maven extension does not (yet) provide a system property to configure 'allowUntrustedServer', so we emulate one here.
-        if (Boolean.parseBoolean(System.getProperty("gradle.enterprise.allowUntrustedServer"))) {
-            logger.info("Allowing untrusted Gradle Enterprise server via Maven extension");
-            api.setAllowUntrustedServer(true);
-        }
     }
 
     private static boolean invokesJetBrainsInfoGoal(MavenSession session) {

--- a/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
+++ b/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
@@ -35,7 +35,7 @@ public final class BuildScanServiceMessageMavenExtension implements GradleEnterp
         }
 
         // The GE Maven extension does not (yet) provide a system property to configure 'allowUntrustedServer', so we emulate one here.
-        if (Boolean.parseBoolean(System.getProperty("gradle.enterprise.allow-untrusted-server"))) {
+        if (Boolean.parseBoolean(System.getProperty("gradle.enterprise.allowUntrustedServer"))) {
             logger.info("Allowing untrusted Gradle Enterprise server via Maven extension");
             api.setAllowUntrustedServer(true);
         }

--- a/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
+++ b/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
@@ -34,8 +34,8 @@ public final class BuildScanServiceMessageMavenExtension implements GradleEnterp
             logger.debug("Finished registering listener capturing build scan link");
         }
 
-        // The GE Maven extension does not provide a system property to configure 'allowUntrustedServer', so we apply the TC config parameter via the GE API.
-        if (Boolean.parseBoolean(System.getenv("TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER"))) {
+        // The GE Maven extension does not (yet) provide a system property to configure 'allowUntrustedServer', so we emulate one here.
+        if (Boolean.parseBoolean(System.getProperty("gradle.enterprise.allow-untrusted-server"))) {
             logger.info("Allowing untrusted Gradle Enterprise server via Maven extension");
             api.setAllowUntrustedServer(true);
         }

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -76,7 +76,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GE_URL_MAVEN_PROPERTY = "gradle.enterprise.url";
 
-    private static final String GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY = "gradle.enterprise.allow-untrusted-server";
+    private static final String GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY = "gradle.enterprise.allowUntrustedServer";
 
     private static final MavenCoordinates GE_EXTENSION_MAVEN_COORDINATES = new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension");
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -66,7 +66,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GE_URL_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_URL";
 
-    private static final String GE_ALLOW_UNTRUSTED_SERVER = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER";
+    private static final String GE_ALLOW_UNTRUSTED_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER";
 
     private static final String GE_PLUGIN_VERSION_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION";
 
@@ -106,7 +106,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private void instrumentGradleRunner(@NotNull BuildRunnerContext runner) {
         addEnvVarIfSet(GE_URL_CONFIG_PARAM, GE_URL_VAR, runner);
-        addEnvVarIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_SERVER, runner);
+        addEnvVarIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_VAR, runner);
         addEnvVarIfSet(GE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_VAR, runner);
         addEnvVarIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_PLUGIN_VERSION_VAR, runner);
 
@@ -128,15 +128,20 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         // Instrument all Gradle builds
         copyInitScriptToGradleUserHome(runner);
         addEnvVarIfSet(GE_URL_CONFIG_PARAM, GE_URL_VAR, runner);
+        addEnvVarIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_VAR, runner);
         addEnvVarIfSet(GE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_VAR, runner);
         addEnvVarIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_PLUGIN_VERSION_VAR, runner);
 
         // Instrument all Maven builds
-        appendEnvVar("MAVEN_OPTS", "-Dmaven.ext.class.path=" + getExtensionsClasspath(runner), runner);
+        String mavenOpts = "-Dmaven.ext.class.path=" + getExtensionsClasspath(runner);
         String geUrl = getOptionalConfigParam(GE_URL_CONFIG_PARAM, runner);
         if (geUrl != null) {
-            appendEnvVar("MAVEN_OPTS", "-Dgradle.enterprise.url=" + geUrl, runner);
+            mavenOpts = mavenOpts + " -D" + GE_URL_MAVEN_PROPERTY + "=" + geUrl;
         }
+        if (getBooleanConfigParam(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, runner)) {
+            mavenOpts = mavenOpts + " -D" + GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY + "=true";
+        }
+        appendEnvVar("MAVEN_OPTS", mavenOpts, runner);
 
         addEnvVar(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN, "1", runner);
     }

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -76,6 +76,8 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GE_URL_MAVEN_PROPERTY = "gradle.enterprise.url";
 
+    private static final String GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY = "gradle.enterprise.allow-untrusted-server";
+
     private static final MavenCoordinates GE_EXTENSION_MAVEN_COORDINATES = new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension");
 
     private static final MavenCoordinates CCUD_EXTENSION_MAVEN_COORDINATES = new MavenCoordinates("com.gradle", "common-custom-user-data-maven-extension");
@@ -104,9 +106,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private void instrumentGradleRunner(@NotNull BuildRunnerContext runner) {
         addEnvVarIfSet(GE_URL_CONFIG_PARAM, GE_URL_VAR, runner);
-        if (getBooleanConfigParam(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, runner)) {
-            addEnvVar(GE_ALLOW_UNTRUSTED_SERVER, "true", runner);
-        }
+        addEnvVarIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_SERVER, runner);
         addEnvVarIfSet(GE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_VAR, runner);
         addEnvVarIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_PLUGIN_VERSION_VAR, runner);
 
@@ -120,10 +120,6 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         // for now, this intentionally ignores the configured extension versions and applies the bundled jars
         String extJarParam = "-Dmaven.ext.class.path=" + getExtensionsClasspath(runner);
         addMavenCmdParam(extJarParam, runner);
-
-        if (getBooleanConfigParam(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, runner)) {
-            addEnvVar(GE_ALLOW_UNTRUSTED_SERVER, "true", runner);
-        }
 
         addEnvVar(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN, "1", runner);
     }
@@ -192,6 +188,7 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
                 extensionApplicationListener.geExtensionApplied(geExtensionVersion);
                 extensionJars.add(getExtensionJar(GRADLE_ENTERPRISE_EXT_MAVEN, runner));
                 addMavenSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, runner);
+                addMavenSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, runner);
             }
         }
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -50,6 +50,8 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private static final String GE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.url";
 
+    private static final String GE_ALLOW_UNTRUSTED_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.allow-untrusted-server";
+
     private static final String GE_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.plugin.version";
 
     private static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.ccud.plugin.version";
@@ -63,6 +65,8 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
     // Environment variables set to instrument the Gradle build
 
     private static final String GE_URL_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_URL";
+
+    private static final String GE_ALLOW_UNTRUSTED_SERVER = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER";
 
     private static final String GE_PLUGIN_VERSION_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION";
 
@@ -100,6 +104,9 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     private void instrumentGradleRunner(@NotNull BuildRunnerContext runner) {
         addEnvVarIfSet(GE_URL_CONFIG_PARAM, GE_URL_VAR, runner);
+        if (getBooleanConfigParam(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, runner)) {
+            addEnvVar(GE_ALLOW_UNTRUSTED_SERVER, "true", runner);
+        }
         addEnvVarIfSet(GE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_VAR, runner);
         addEnvVarIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_PLUGIN_VERSION_VAR, runner);
 
@@ -113,6 +120,10 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
         // for now, this intentionally ignores the configured extension versions and applies the bundled jars
         String extJarParam = "-Dmaven.ext.class.path=" + getExtensionsClasspath(runner);
         addMavenCmdParam(extJarParam, runner);
+
+        if (getBooleanConfigParam(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, runner)) {
+            addEnvVar(GE_ALLOW_UNTRUSTED_SERVER, "true", runner);
+        }
 
         addEnvVar(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN, "1", runner);
     }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -58,6 +58,7 @@ def getInputParam = { String name ->
     return System.getProperty(name) ?: System.getenv(envVarName)
 }
 def geUrl = getInputParam('teamCityBuildScanPlugin.gradle-enterprise.url')
+def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('teamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server'))
 def gePluginVersion = getInputParam('teamCityBuildScanPlugin.gradle-enterprise.plugin.version')
 def ccudPluginVersion = getInputParam('teamCityBuildScanPlugin.ccud.plugin.version')
 
@@ -96,6 +97,10 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
                     buildScan.publishAlways()
                     buildScan.server = geUrl
+                    if (geAllowUntrustedServer) {
+                        logger.quiet("Allowing untrusted Gradle Enterprise server via init script")
+                        buildScan.allowUntrustedServer = true
+                    }
                 }
             }
 
@@ -123,6 +128,10 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
                     ext.buildScan.publishAlways()
                     ext.server = geUrl
+                    if (geAllowUntrustedServer) {
+                        logger.quiet("Allowing untrusted Gradle Enterprise server via init script")
+                        ext.allowUntrustedServer = true
+                    }
                 }
             }
         }

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
@@ -5,6 +5,7 @@ import jetbrains.buildServer.agent.BuildRunnerContext
 import jetbrains.buildServer.util.EventDispatcher
 import nu.studer.teamcity.buildscan.agent.BuildScanServiceMessageInjector
 import nu.studer.teamcity.buildscan.agent.ExtensionApplicationListener
+import org.gradle.testkit.runner.BuildResult
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -414,6 +415,7 @@ class GradleEnterpriseExtensionApplicationTest extends Specification {
 
         and:
         configParameters.put('buildScanPlugin.gradle-enterprise.url', GE_URL)
+        configParameters.put('buildScanPlugin.gradle-enterprise.allow-untrusted-server', "true")
         configParameters.put('buildScanPlugin.gradle-enterprise.extension.version', GE_EXTENSION_VERSION)
 
         when:
@@ -427,6 +429,7 @@ class GradleEnterpriseExtensionApplicationTest extends Specification {
         and:
         outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
+        outputContainsAllowUntrustedServerMessage(output)
 
         where:
         jdkCompatibleMavenVersion << SUPPORTED_MAVEN_VERSIONS
@@ -512,6 +515,12 @@ class GradleEnterpriseExtensionApplicationTest extends Specification {
     void outputMissesTeamCityServiceMessageBuildScanUrl(String output) {
         def serviceMsg = "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_SCAN_URL:${GE_URL}/s/"
         assert !output.contains(serviceMsg)
+    }
+
+    void outputContainsAllowUntrustedServerMessage(String output) {
+        def allowUntrustedLogMessage = "Allowing untrusted Gradle Enterprise server via Maven extension"
+        assert output.contains(allowUntrustedLogMessage)
+        assert 1 == output.count(allowUntrustedLogMessage)
     }
 
     static final class JdkCompatibleMavenVersion {

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
@@ -429,7 +429,6 @@ class GradleEnterpriseExtensionApplicationTest extends Specification {
         and:
         outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
-        outputContainsAllowUntrustedServerMessage(output)
 
         where:
         jdkCompatibleMavenVersion << SUPPORTED_MAVEN_VERSIONS
@@ -515,12 +514,6 @@ class GradleEnterpriseExtensionApplicationTest extends Specification {
     void outputMissesTeamCityServiceMessageBuildScanUrl(String output) {
         def serviceMsg = "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_SCAN_URL:${GE_URL}/s/"
         assert !output.contains(serviceMsg)
-    }
-
-    void outputContainsAllowUntrustedServerMessage(String output) {
-        def allowUntrustedLogMessage = "Allowing untrusted Gradle Enterprise server via Maven extension"
-        assert output.contains(allowUntrustedLogMessage)
-        assert 1 == output.count(allowUntrustedLogMessage)
     }
 
     static final class JdkCompatibleMavenVersion {


### PR DESCRIPTION
Provides a central mechanism for TC users to configure `allowUntrustedServer` for the configured GE URL, via a `buildScanPlugin.gradle-enterprise.allow-untrusted-server' configuration parameter. This parameter is supported for Gradle and Maven with both core and command-line runners.

- For Gradle the setting is applied in the init script
- For Maven the setting is mapped to a System Property supported by the TC Maven Extension