### PR TITLE
GitHub Actions improvements

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -24,5 +24,5 @@ jobs:
             -   name: Build and bundle plugin artifact
                 run: ./gradlew clean build -Porg.gradle.java.installations.fromEnv=JAVA_HOME_6_0_119_X64 -PjavaCompilerVersion=6 -Pteamcity-build-scan-plugin.acceptGradleTOS=true
                 env:
-                    GRADLE_ENTERPRISE_TEST_INSTANCE: https://ge.solutions-team.gradle.com
+                    GRADLE_ENTERPRISE_TEST_INSTANCE: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN != null && 'https://ge.solutions-team.gradle.com' || '' }} # Use GE Solutions server only if access token is available
                     GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -1,6 +1,11 @@
 name: Verify Build
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+    push:
+        branches-ignore:
+            - master # The `development-release` runs on push to `master` and is a superset of this workflow
+    pull_request:
+    workflow_dispatch:
 
 jobs:
     verification:

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -25,4 +25,4 @@ jobs:
                 run: ./gradlew clean build -Porg.gradle.java.installations.fromEnv=JAVA_HOME_6_0_119_X64 -PjavaCompilerVersion=6 -Pteamcity-build-scan-plugin.acceptGradleTOS=true
                 env:
                     GRADLE_ENTERPRISE_TEST_INSTANCE: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN != null && 'https://ge.solutions-team.gradle.com' || '' }} # Use GE Solutions server only if access token is available
-                    GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+                    GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN != null && secrets.GE_SOLUTIONS_ACCESS_TOKEN || 'dummy.server=dummy_value' }} # GE Gradle Plugin barfs on empty value

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -28,7 +28,7 @@ jobs:
             -   name: Build and bundle plugin artifact
                 run: ./gradlew clean build githubRelease -Porg.gradle.java.installations.fromEnv=JAVA_HOME_6_0_119_X64 -PjavaCompilerVersion=6 -Pteamcity-build-scan-plugin.acceptGradleTOS=true
                 env:
-                    GRADLE_ENTERPRISE_TEST_INSTANCE: https://ge.solutions-team.gradle.com
+                    GRADLE_ENTERPRISE_TEST_INSTANCE: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN != null && 'https://ge.solutions-team.gradle.com' || '' }} # Use GE Solutions server only if access token is available
                     GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
                     TEAMCITY_PLUGIN_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -   name: Upload plugin artifact

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -29,7 +29,7 @@ jobs:
                 run: ./gradlew clean build githubRelease -Porg.gradle.java.installations.fromEnv=JAVA_HOME_6_0_119_X64 -PjavaCompilerVersion=6 -Pteamcity-build-scan-plugin.acceptGradleTOS=true
                 env:
                     GRADLE_ENTERPRISE_TEST_INSTANCE: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN != null && 'https://ge.solutions-team.gradle.com' || '' }} # Use GE Solutions server only if access token is available
-                    GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+                    GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN != null && secrets.GE_SOLUTIONS_ACCESS_TOKEN || 'dummy.server=dummy_value' }} # GE Gradle Plugin barfs on empty value
                     TEAMCITY_PLUGIN_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -   name: Upload plugin artifact
                 uses: actions/upload-artifact@v3

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
@@ -22,7 +22,7 @@ class GradleEnterpriseExtensionApplicationTest extends Specification {
 new JdkCompatibleMavenVersion('3.8.5', 7, 11)
     ]
 
-    static final String GE_URL = System.getenv('GRADLE_ENTERPRISE_TEST_INSTANCE')
+    static final String GE_URL = System.getenv('GRADLE_ENTERPRISE_TEST_INSTANCE') ?: null // Replace empty string with null
     static final String GE_EXTENSION_VERSION = '1.14.2'
     static final String CCUD_EXTENSION_VERSION = '1.10.1'
 


### PR DESCRIPTION
- Do not fail `build-verification` or `development-release` workflows if `GRADLE_ENTERPRISE_ACCESS_KEY` secret is unavailable. This allows workflows to pass for PRs submitted from forked repositories.
- Do not run `build-verification` and `development-release` workflows on the same triggers. This avoids duplicating the build effort on pushes to `master`.