### PR TITLE
Make the `build-scan-init` script safer to apply to Gradle User Home

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,17 @@ It is recommended that you use the [latest Gradle Enterprise Gradle plugin versi
 
 If you use TeamCity's GradleRunner to launch your Gradle builds, there is nothing special to do.
 
-If, and only if, you do not use TeamCity's GradleRunner to launch Gradle builds, apply the [TeamCity build scan Gradle plugin](https://github.com/etiennestuder/gradle-build-scan-teamcity-plugin) to your Gradle builds in order to
-notify TeamCity about the build scans that were published while running a build.
+If you use TeamCity's CommmandLineRunner to launch your Gradle builds, you can opt in to enable build scan detection using the `buildScanPlugin.command-line-build-step.enabled` configuration parameter. (See below)
 
-If you do not use TeamCity's GradleRunner to launch Gradle builds and you do not apply the [TeamCity build scan Gradle plugin](https://github.com/etiennestuder/gradle-build-scan-teamcity-plugin) to your Gradle builds, you can still get integration with build scans, but it requires your build logs being parsed for build scan links. In case of huge build logs, this can put a significant toll on the performance of your TeamCity instance. You can enable the parsing of the build logs by creating a TeamCity configuration parameter with name `BUILD_SCAN_LOG_PARSING` and setting the value to `true`.
+If the first 2 mechanisms will not work for you Gradle build configurations, you can still get integration with build scans, but it requires your build logs being parsed for build scan links. In case of huge build logs, this can put a significant toll on the performance of your TeamCity instance. You can enable the parsing of the build logs by creating a TeamCity configuration parameter with name `BUILD_SCAN_LOG_PARSING` and setting the value to `true`.
 
 ### Maven builds
 
 If you use TeamCity's MavenRunner to launch Maven builds, there is nothing special to do.
 
-If you do not use TeamCity's MavenRunner to launch Maven builds, you can still get integration with build scans, but it requires your build logs being parsed for build scan links. In case of huge build logs, this can put a significant toll on the performance of your TeamCity instance. You can enable the parsing of the build logs by creating a TeamCity configuration parameter with name `BUILD_SCAN_LOG_PARSING` and setting the value to `true`.
+If you use TeamCity's CommmandLineRunner to launch your Maven builds, you can opt in to enable build scan detection using the `buildScanPlugin.command-line-build-step.enabled` configuration parameter. (See below)
+
+If the first 2 mechanisms will not work for you Maven build configurations, you can still get integration with build scans, but it requires your build logs being parsed for build scan links. In case of huge build logs, this can put a significant toll on the performance of your TeamCity instance. You can enable the parsing of the build logs by creating a TeamCity configuration parameter with name `BUILD_SCAN_LOG_PARSING` and setting the value to `true`.
 
 # Installation
 
@@ -90,6 +91,7 @@ The higher in TeamCity's project hierarchy the configuration parameters are appl
    - `buildScanPlugin.ccud.plugin.version` - the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply (
      opt)
    - `buildScanPlugin.gradle.plugin-repository.url` - the URL of the repository to use when resolving the GE and CCUD plugins (opt)
+   - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for all jobs using the CommandLineRunner (opt)
 
 1. Trigger your Gradle build.
 
@@ -109,6 +111,7 @@ _Note: For Gradle, the Common Custom User Data Gradle plugin must be at least ve
    - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - whether it is ok to communicate with an untrusted server (opt)
    - `buildScanPlugin.gradle-enterprise.extension.version` - the version of the [Gradle Enterprise Maven extension](https://docs.gradle.com/enterprise/maven-extension/) to apply
    - `buildScanPlugin.ccud.extension.version` - the version of the [Common Custom User Data Maven extension](https://github.com/gradle/common-custom-user-data-maven-extension) to apply (opt)
+   - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for all jobs using the CommandLineRunner (opt)
 
 1. Trigger your Maven build.
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * builds.
  */
 @SuppressWarnings({"SameParameterValue", "ResultOfMethodCallIgnored"})
-public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
+public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
 
     // TeamCity Gradle runner
 
@@ -171,11 +171,15 @@ public final class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter
 
     @NotNull
     private File getInitScriptsDir() {
-        String gradleUserHomeEnv = System.getenv("GRADLE_USER_HOME");
-        File gradleUserHome = gradleUserHomeEnv == null
+        return new File(getGradleUserHome(), "init.d");
+    }
+
+    @NotNull
+    protected File getGradleUserHome() {
+        String gradleUserHomeOverride = System.getProperty("gradle.user.home", System.getenv("GRADLE_USER_HOME"));
+        return gradleUserHomeOverride == null
             ? new File(System.getProperty("user.home"), ".gradle")
-            : new File(gradleUserHomeEnv);
-        return new File(gradleUserHome, "init.d");
+            : new File(gradleUserHomeOverride);
     }
 
     private String getMavenInvocationArgs(BuildRunnerContext runner) {

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -13,6 +13,13 @@ initscript {
         def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
         return System.getProperty(name) ?: System.getenv(envVarName)
     }
+
+    def requestedInitScriptName = getInputParam('teamCityBuildScanPlugin.init-script-name')
+    def initScriptName = buildscript.sourceFile.name
+    if (requestedInitScriptName != initScriptName) {
+        return
+    }
+
     def pluginRepositoryUrl = getInputParam('teamCityBuildScanPlugin.gradle.plugin-repository.url')
     def gePluginVersion = getInputParam('teamCityBuildScanPlugin.gradle-enterprise.plugin.version')
     def ccudPluginVersion = getInputParam('teamCityBuildScanPlugin.ccud.plugin.version')
@@ -61,6 +68,14 @@ def getInputParam = { String name ->
     def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
     return System.getProperty(name) ?: System.getenv(envVarName)
 }
+
+def requestedInitScriptName = getInputParam('teamCityBuildScanPlugin.init-script-name')
+def initScriptName = buildscript.sourceFile.name
+if (requestedInitScriptName != initScriptName) {
+    logger.quiet("Ignoring '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
+    return
+}
+
 def geUrl = getInputParam('teamCityBuildScanPlugin.gradle-enterprise.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('teamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server'))
 def gePluginVersion = getInputParam('teamCityBuildScanPlugin.gradle-enterprise.plugin.version')

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TestBuildScanServiceMessageInjector.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TestBuildScanServiceMessageInjector.groovy
@@ -1,0 +1,20 @@
+package nu.studer.teamcity.buildscan.agent
+
+import jetbrains.buildServer.agent.AgentLifeCycleListener
+import jetbrains.buildServer.util.EventDispatcher
+import org.jetbrains.annotations.NotNull
+
+class TestBuildScanServiceMessageInjector extends BuildScanServiceMessageInjector {
+    private final File gradleUserHome
+
+    TestBuildScanServiceMessageInjector(File gradleUserHome, @NotNull EventDispatcher<AgentLifeCycleListener> eventDispatcher, @NotNull ExtensionApplicationListener extensionApplicationListener) {
+        super(eventDispatcher, extensionApplicationListener)
+        this.gradleUserHome = gradleUserHome
+    }
+
+    @NotNull
+    @Override
+    protected File getGradleUserHome() {
+        return gradleUserHome
+    }
+}

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TestContext.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TestContext.groovy
@@ -25,12 +25,14 @@ class TestContext implements BuildRunnerContext {
 
     private final String runType
     private final AgentRunningBuild agentRunningBuild
+    private final BuildParametersMap buildParametersMap
     private final Map<String, String> configParameters
     private final Map<String, String> runnerParameters
 
     TestContext(String runType, File agentTempDirectory, Map<String, String> configParameters, Map<String, String> runnerParameters) {
         this.runType = runType
         this.agentRunningBuild = new TestAgentBuild(agentTempDirectory)
+        this.buildParametersMap = new TestBuildParametersMap()
         this.configParameters = configParameters
         this.runnerParameters = runnerParameters
     }
@@ -62,7 +64,7 @@ class TestContext implements BuildRunnerContext {
 
     @Override
     BuildParametersMap getBuildParameters() {
-        return null
+        return buildParametersMap
     }
 
     @Override
@@ -77,17 +79,17 @@ class TestContext implements BuildRunnerContext {
 
     @Override
     void addSystemProperty(@NotNull String key, @NotNull String value) {
-
+        buildParametersMap.systemProperties.put(key, value)
     }
 
     @Override
     void addEnvironmentVariable(@NotNull String key, @NotNull String value) {
-
+        buildParametersMap.environmentVariables.put(key, value)
     }
 
     @Override
     void addConfigParameter(@NotNull String key, @NotNull String value) {
-
+        configParameters.put(key, value)
     }
 
     @Override
@@ -118,6 +120,25 @@ class TestContext implements BuildRunnerContext {
     @Override
     VirtualContext getVirtualContext() {
         return null
+    }
+
+    private class TestBuildParametersMap implements BuildParametersMap {
+        private Map<String,String> envVars = [:]
+        private Map<String,String> sysProps = [:]
+        @Override
+        Map<String, String> getEnvironmentVariables() {
+            return envVars
+        }
+
+        @Override
+        Map<String, String> getSystemProperties() {
+            return sysProps
+        }
+
+        @Override
+        Map<String, String> getAllParameters() {
+            return null
+        }
     }
 
     private class TestAgentBuild implements AgentRunningBuild {

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TestContext.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TestContext.groovy
@@ -1,4 +1,4 @@
-package nu.studer.teamcity.buildscan.agent.maven
+package nu.studer.teamcity.buildscan.agent
 
 import jetbrains.buildServer.agent.AgentBuildFeature
 import jetbrains.buildServer.agent.AgentCheckoutMode
@@ -23,11 +23,13 @@ import org.jetbrains.annotations.NotNull
 
 class TestContext implements BuildRunnerContext {
 
+    private final String runType
     private final AgentRunningBuild agentRunningBuild
     private final Map<String, String> configParameters
     private final Map<String, String> runnerParameters
 
-    TestContext(File agentTempDirectory, Map<String, String> configParameters, Map<String, String> runnerParameters) {
+    TestContext(String runType, File agentTempDirectory, Map<String, String> configParameters, Map<String, String> runnerParameters) {
+        this.runType = runType
         this.agentRunningBuild = new TestAgentBuild(agentTempDirectory)
         this.configParameters = configParameters
         this.runnerParameters = runnerParameters
@@ -50,7 +52,7 @@ class TestContext implements BuildRunnerContext {
 
     @Override
     String getRunType() {
-        return "Maven2"
+        return runType
     }
 
     @Override

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GradleEnterprisePluginApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GradleEnterprisePluginApplicationTest.groovy
@@ -17,7 +17,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig()
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputMissesGePluginApplicationViaInitScript(result)
@@ -30,12 +30,12 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         jdkCompatibleGradleVersion << GRADLE_VERSIONS_2_AND_HIGHER
     }
 
-    def "applies GE plugin via init script when not defined in project, using sys props configuration (#jdkCompatibleGradleVersion)"() {
+    def "applies GE plugin via init script when not defined in project (#jdkCompatibleGradleVersion)"() {
         assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
 
         when:
         def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, gePluginVersion: GE_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputContainsGePluginApplicationViaInitScript(result, jdkCompatibleGradleVersion.gradleVersion)
@@ -49,25 +49,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         jdkCompatibleGradleVersion << GRADLE_VERSIONS_2_AND_HIGHER
     }
 
-    def "applies GE plugin via init script when not defined in project, using env vars configuration (#jdkCompatibleGradleVersion)"() {
-        assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
-
-        when:
-        def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, gePluginVersion: GE_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, [], gePluginConfig.toEnvVars())
-
-        then:
-        outputContainsGePluginApplicationViaInitScript(result, jdkCompatibleGradleVersion.gradleVersion)
-        outputMissesCcudPluginApplicationViaInitScript(result)
-
-        and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
-        outputContainsTeamCityServiceMessageBuildScanUrl(result)
-
-        where:
-        jdkCompatibleGradleVersion << GRADLE_VERSIONS_3_5_AND_HIGHER
-    }
-
     def "applies GE plugin via project when defined in project (#jdkCompatibleGradleVersion)"() {
         assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
 
@@ -76,7 +57,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, gePluginVersion: GE_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputMissesGePluginApplicationViaInitScript(result)
@@ -95,7 +76,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, gePluginVersion: GE_PLUGIN_VERSION, ccudPluginVersion: CCUD_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputContainsGePluginApplicationViaInitScript(result, jdkCompatibleGradleVersion.gradleVersion)
@@ -109,7 +90,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         jdkCompatibleGradleVersion << GRADLE_VERSIONS_4_AND_HIGHER
     }
 
-    def "applies CCUD plugin via init script when not defined in project where GE plugin defined in project, using sys props configuration (#jdkCompatibleGradleVersion)"() {
+    def "applies CCUD plugin via init script when not defined in project where GE plugin defined in project (#jdkCompatibleGradleVersion)"() {
         assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
 
         given:
@@ -117,29 +98,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, gePluginVersion: GE_PLUGIN_VERSION, ccudPluginVersion: CCUD_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
-
-        then:
-        outputMissesGePluginApplicationViaInitScript(result)
-        outputContainsCcudPluginApplicationViaInitScript(result)
-
-        and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
-        outputContainsTeamCityServiceMessageBuildScanUrl(result)
-
-        where:
-        jdkCompatibleGradleVersion << GRADLE_VERSIONS_4_AND_HIGHER
-    }
-
-    def "applies CCUD plugin via init script when not defined in project where GE plugin defined in project, using env vars configuration (#jdkCompatibleGradleVersion)"() {
-        assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
-
-        given:
-        declareGePluginApplication(jdkCompatibleGradleVersion.gradleVersion)
-
-        when:
-        def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, gePluginVersion: GE_PLUGIN_VERSION, ccudPluginVersion: CCUD_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, [], gePluginConfig.toEnvVars())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputMissesGePluginApplicationViaInitScript(result)
@@ -161,7 +120,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, gePluginVersion: GE_PLUGIN_VERSION, ccudPluginVersion: CCUD_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputMissesGePluginApplicationViaInitScript(result)
@@ -183,7 +142,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig(geUrl: URI.create('https://ge-server.invalid'), geAllowUntrustedServer: true, gePluginVersion: GE_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputMissesGePluginApplicationViaInitScript(result)
@@ -202,7 +161,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, geAllowUntrustedServer: true, gePluginVersion: GE_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputContainsGePluginApplicationViaInitScript(result, jdkCompatibleGradleVersion.gradleVersion)
@@ -223,7 +182,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig(gradlePluginRepositoryUrl: new URI('https://plugins.grdev.net/m2'), geUrl: mockScansServer.address, geAllowUntrustedServer: false, gePluginVersion: GE_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputContainsGePluginApplicationViaInitScript(result, jdkCompatibleGradleVersion.gradleVersion)
@@ -240,7 +199,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, gePluginVersion: GE_PLUGIN_VERSION, ccudPluginVersion: '1.6.6')
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps())
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:
         outputMissesGePluginApplicationViaInitScript(result)
@@ -256,7 +215,7 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
 
         when:
         def gePluginConfig = new TcPluginConfig(geUrl: URI.create('https://ge-server.invalid'), gePluginVersion: GE_PLUGIN_VERSION, ccudPluginVersion: CCUD_PLUGIN_VERSION)
-        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig.toSysProps() + ["-Dgradle.enterprise.url=$mockScansServer.address".toString()])
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig, ["-Dgradle.enterprise.url=$mockScansServer.address".toString()])
 
         then:
         outputContainsGePluginApplicationViaInitScript(result, jdkCompatibleGradleVersion.gradleVersion)
@@ -313,55 +272,4 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         assert result.output.contains(repositoryInfo)
         assert 1 == result.output.count(repositoryInfo)
     }
-
-    static final class TcPluginConfig {
-
-        URI gradlePluginRepositoryUrl
-        URI geUrl
-        boolean geAllowUntrustedServer
-        String gePluginVersion
-        String ccudPluginVersion
-
-        List<String> toSysProps() {
-            def jvmArgs = []
-            if (gradlePluginRepositoryUrl) {
-                jvmArgs << "-DteamCityBuildScanPlugin.gradle.plugin-repository.url=$gradlePluginRepositoryUrl".toString()
-            }
-            if (geUrl) {
-                jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.url=$geUrl".toString()
-            }
-            if (geAllowUntrustedServer) {
-                jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server=true"
-            }
-            if (gePluginVersion) {
-                jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.plugin.version=$gePluginVersion".toString()
-            }
-            if (ccudPluginVersion) {
-                jvmArgs << "-DteamCityBuildScanPlugin.ccud.plugin.version=$ccudPluginVersion".toString()
-            }
-            jvmArgs
-        }
-
-        Map<String, String> toEnvVars() {
-            Map<String, String> envVars = [:]
-            if (gradlePluginRepositoryUrl) {
-                envVars.put 'TEAMCITYBUILDSCANPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL', gradlePluginRepositoryUrl.toString()
-            }
-            if (geUrl) {
-                envVars.put 'TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_URL', geUrl.toString()
-            }
-            if (geAllowUntrustedServer) {
-                envVars.put 'TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER', 'true'
-            }
-            if (gePluginVersion) {
-                envVars.put 'TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION', gePluginVersion
-            }
-            if (ccudPluginVersion) {
-                envVars.put 'TEAMCITYBUILDSCANPLUGIN_CCUD_PLUGIN_VERSION', ccudPluginVersion
-            }
-            envVars
-        }
-
-    }
-
 }

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/TcPluginConfig.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/TcPluginConfig.groovy
@@ -30,7 +30,7 @@ final class TcPluginConfig {
 
      // Generate sysProps for the init-script directly, for Gradle versions where TestKit doesn't support env vars
      List<String> toSysProps() {
-         def jvmArgs = []
+         def jvmArgs = ["-DteamCityBuildScanPlugin.init-script-name=build-scan-init.gradle"]
          if (gradlePluginRepositoryUrl) {
              jvmArgs << "-DteamCityBuildScanPlugin.gradle.plugin-repository.url=$gradlePluginRepositoryUrl".toString()
          }

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/TcPluginConfig.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/TcPluginConfig.groovy
@@ -2,50 +2,50 @@ package nu.studer.teamcity.buildscan.agent.gradle
 
 final class TcPluginConfig {
 
-     URI gradlePluginRepositoryUrl
-     URI geUrl
-     boolean geAllowUntrustedServer
-     String gePluginVersion
-     String ccudPluginVersion
+    URI gradlePluginRepositoryUrl
+    URI geUrl
+    boolean geAllowUntrustedServer
+    String gePluginVersion
+    String ccudPluginVersion
 
-     Map<String, String> toConfigProperties() {
-         Map<String, String> configProps = [:]
-         if (gradlePluginRepositoryUrl) {
-             configProps.put 'buildScanPlugin.gradle.plugin-repository.url', gradlePluginRepositoryUrl.toString()
-         }
-         if (geUrl) {
-             configProps.put 'buildScanPlugin.gradle-enterprise.url', geUrl.toString()
-         }
-         if (geAllowUntrustedServer) {
-             configProps.put 'buildScanPlugin.gradle-enterprise.allow-untrusted-server', 'true'
-         }
-         if (gePluginVersion) {
-             configProps.put 'buildScanPlugin.gradle-enterprise.plugin.version', gePluginVersion
-         }
-         if (ccudPluginVersion) {
-             configProps.put 'buildScanPlugin.ccud.plugin.version', ccudPluginVersion
-         }
-         configProps
-     }
+    Map<String, String> toConfigProperties() {
+        Map<String, String> configProps = [:]
+        if (gradlePluginRepositoryUrl) {
+            configProps.put 'buildScanPlugin.gradle.plugin-repository.url', gradlePluginRepositoryUrl.toString()
+        }
+        if (geUrl) {
+            configProps.put 'buildScanPlugin.gradle-enterprise.url', geUrl.toString()
+        }
+        if (geAllowUntrustedServer) {
+            configProps.put 'buildScanPlugin.gradle-enterprise.allow-untrusted-server', 'true'
+        }
+        if (gePluginVersion) {
+            configProps.put 'buildScanPlugin.gradle-enterprise.plugin.version', gePluginVersion
+        }
+        if (ccudPluginVersion) {
+            configProps.put 'buildScanPlugin.ccud.plugin.version', ccudPluginVersion
+        }
+        configProps
+    }
 
-     // Generate sysProps for the init-script directly, for Gradle versions where TestKit doesn't support env vars
-     List<String> toSysProps() {
-         def jvmArgs = ["-DteamCityBuildScanPlugin.init-script-name=build-scan-init.gradle"]
-         if (gradlePluginRepositoryUrl) {
-             jvmArgs << "-DteamCityBuildScanPlugin.gradle.plugin-repository.url=$gradlePluginRepositoryUrl".toString()
-         }
-         if (geUrl) {
-             jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.url=$geUrl".toString()
-         }
-         if (geAllowUntrustedServer) {
-             jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server=true"
-         }
-         if (gePluginVersion) {
-             jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.plugin.version=$gePluginVersion".toString()
-         }
-         if (ccudPluginVersion) {
-             jvmArgs << "-DteamCityBuildScanPlugin.ccud.plugin.version=$ccudPluginVersion".toString()
-         }
-         jvmArgs
-     }
- }
+    // Generate sysProps for the init-script directly, for Gradle versions where TestKit doesn't support env vars
+    List<String> toSysProps() {
+        def jvmArgs = ["-DteamCityBuildScanPlugin.init-script-name=build-scan-init.gradle"]
+        if (gradlePluginRepositoryUrl) {
+            jvmArgs << "-DteamCityBuildScanPlugin.gradle.plugin-repository.url=$gradlePluginRepositoryUrl".toString()
+        }
+        if (geUrl) {
+            jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.url=$geUrl".toString()
+        }
+        if (geAllowUntrustedServer) {
+            jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server=true"
+        }
+        if (gePluginVersion) {
+            jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.plugin.version=$gePluginVersion".toString()
+        }
+        if (ccudPluginVersion) {
+            jvmArgs << "-DteamCityBuildScanPlugin.ccud.plugin.version=$ccudPluginVersion".toString()
+        }
+        jvmArgs
+    }
+}

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/TcPluginConfig.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/TcPluginConfig.groovy
@@ -1,0 +1,51 @@
+package nu.studer.teamcity.buildscan.agent.gradle
+
+final class TcPluginConfig {
+
+     URI gradlePluginRepositoryUrl
+     URI geUrl
+     boolean geAllowUntrustedServer
+     String gePluginVersion
+     String ccudPluginVersion
+
+     Map<String, String> toConfigProperties() {
+         Map<String, String> configProps = [:]
+         if (gradlePluginRepositoryUrl) {
+             configProps.put 'buildScanPlugin.gradle.plugin-repository.url', gradlePluginRepositoryUrl.toString()
+         }
+         if (geUrl) {
+             configProps.put 'buildScanPlugin.gradle-enterprise.url', geUrl.toString()
+         }
+         if (geAllowUntrustedServer) {
+             configProps.put 'buildScanPlugin.gradle-enterprise.allow-untrusted-server', 'true'
+         }
+         if (gePluginVersion) {
+             configProps.put 'buildScanPlugin.gradle-enterprise.plugin.version', gePluginVersion
+         }
+         if (ccudPluginVersion) {
+             configProps.put 'buildScanPlugin.ccud.plugin.version', ccudPluginVersion
+         }
+         configProps
+     }
+
+     // Generate sysProps for the init-script directly, for Gradle versions where TestKit doesn't support env vars
+     List<String> toSysProps() {
+         def jvmArgs = []
+         if (gradlePluginRepositoryUrl) {
+             jvmArgs << "-DteamCityBuildScanPlugin.gradle.plugin-repository.url=$gradlePluginRepositoryUrl".toString()
+         }
+         if (geUrl) {
+             jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.url=$geUrl".toString()
+         }
+         if (geAllowUntrustedServer) {
+             jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server=true"
+         }
+         if (gePluginVersion) {
+             jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.plugin.version=$gePluginVersion".toString()
+         }
+         if (ccudPluginVersion) {
+             jvmArgs << "-DteamCityBuildScanPlugin.ccud.plugin.version=$ccudPluginVersion".toString()
+         }
+         jvmArgs
+     }
+ }

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/TcPluginConfig.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/TcPluginConfig.groovy
@@ -1,12 +1,13 @@
 package nu.studer.teamcity.buildscan.agent.gradle
 
 final class TcPluginConfig {
-
     URI gradlePluginRepositoryUrl
     URI geUrl
     boolean geAllowUntrustedServer
     String gePluginVersion
     String ccudPluginVersion
+    String runner = "gradle-runner"
+    boolean enableCommandLineRunner
 
     Map<String, String> toConfigProperties() {
         Map<String, String> configProps = [:]
@@ -24,6 +25,9 @@ final class TcPluginConfig {
         }
         if (ccudPluginVersion) {
             configProps.put 'buildScanPlugin.ccud.plugin.version', ccudPluginVersion
+        }
+        if (enableCommandLineRunner) {
+            configProps.put 'buildScanPlugin.command-line-build-step.enabled', 'true'
         }
         configProps
     }
@@ -44,6 +48,9 @@ final class TcPluginConfig {
             jvmArgs << "-DteamCityBuildScanPlugin.gradle-enterprise.plugin.version=$gePluginVersion".toString()
         }
         if (ccudPluginVersion) {
+            jvmArgs << "-DteamCityBuildScanPlugin.ccud.plugin.version=$ccudPluginVersion".toString()
+        }
+        if (enableCommandLineRunner) {
             jvmArgs << "-DteamCityBuildScanPlugin.ccud.plugin.version=$ccudPluginVersion".toString()
         }
         jvmArgs

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
@@ -5,7 +5,7 @@ import jetbrains.buildServer.agent.BuildRunnerContext
 import jetbrains.buildServer.util.EventDispatcher
 import nu.studer.teamcity.buildscan.agent.BuildScanServiceMessageInjector
 import nu.studer.teamcity.buildscan.agent.ExtensionApplicationListener
-import org.gradle.testkit.runner.BuildResult
+import nu.studer.teamcity.buildscan.agent.TestContext
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -51,7 +51,7 @@ new JdkCompatibleMavenVersion('3.8.5', 7, 11)
         runnerParameters.put('teamcity.build.checkoutDir', testProjectDir.absolutePath)
         runnerParameters.put('teamcity.build.workingDir', testProjectDir.absolutePath)
 
-        context = new TestContext(agentTempDir, configParameters, runnerParameters)
+        context = new TestContext("Maven2", agentTempDir, configParameters, runnerParameters)
         extensionApplicationListener = Mock(ExtensionApplicationListener)
         injector = new BuildScanServiceMessageInjector(EventDispatcher.create(AgentLifeCycleListener.class), extensionApplicationListener)
     }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+- 'build-scan-init' script is safer to copy into Gradle User Home, as it has no effect without corresponding Env Var to activate.


### PR DESCRIPTION
- Refactored tests for Gradle jobs to use the `BuildScanServiceMessageInjector` to map TC Config params to Env Vars.
- Made the `build-scan-init` script safer to apply
    - Script has no impact in the absence of Env Var with value matching script name
    - When applying script directly via `--init-script`, then file name is 'build-scan-init.gradle'
    - When script is added to Gradle User Home, it has a unique name: build-scan-init-<timestamp>.gradle
    - Each intercepted job is run with the matching environment variable for the init-script
- Added test coverage for integration with CommandLine jobs