### PR TITLE
Bump Gradle Wrapper from 7.5 to 7.5.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionSha256Sum=f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bumps Gradle Wrapper from 7.5 to 7.5.1.

Release notes of Gradle 7.5.1 can be found here:
https://docs.gradle.org/7.5.1/release-notes.html