### PR TITLE
Make the Maven version check configurable and disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ _Note: For Maven, the Gradle Enterprise Maven extension and the Common Custom Us
 
 #### Example Configuration
 
-<img width="591" alt="gradle-enterprise-connection-dialog" src="https://user-images.githubusercontent.com/625514/185425268-7d4b363f-941b-49c8-9d88-1e68e2551e9a.png">
+<img width="591" alt="gradle-enterprise-connection-dialog" src="https://user-images.githubusercontent.com/625514/190648291-0315b67a-e0bf-4c78-b54c-77a2c5858aa2.png">
 
 ### Injecting Gradle Enterprise via Configuration Parameters
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ _Note: For Gradle, the Common Custom User Data Gradle plugin must be at least ve
     - `buildScanPlugin.ccud.extension.custom.coordinates` - the coordinates of a custom Common Custom User Data Maven Extension or of a custom extension that has a transitive dependency on it
     - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for _Command Line_ build steps; by default only steps using the _Maven_ runner are enabled
     - `buildScanPlugin.log-parsing.enabled` - use log parsing to extract Build Scan urls (if the default mechanism for capturing Build Scan links is not working)
+    - `buildScanPlugin.maven-version-check.enabled` - enable a Maven version check to ensure that the Gradle Enterprise Maven Extension is not applied to Maven builds lower than version 3.3.1
 
 3. Trigger your Maven build.
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -69,6 +69,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String CUSTOM_GE_EXTENSION_COORDINATES_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.extension.custom.coordinates";
     private static final String CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM = "buildScanPlugin.ccud.extension.custom.coordinates";
     private static final String INSTRUMENT_COMMAND_LINE_RUNNER_CONFIG_PARAM = "buildScanPlugin.command-line-build-step.enabled";
+    private static final String IS_MAVEN_VERSION_CHECK_ENABLED_PARAM = "buildScanPlugin.maven-version-check.enabled";
 
     // Environment variables set to instrument the Gradle build
 
@@ -212,8 +213,10 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     }
 
     private String getMavenInvocationArgs(BuildRunnerContext runner) {
+        boolean isMavenVersionCheckEnabled = getBooleanConfigParam(IS_MAVEN_VERSION_CHECK_ENABLED_PARAM, runner);
+
         // only check for the Maven version used by this build run in non-virtual environments since it cannot be checked reliably in virtual envs
-        if (!runner.isVirtualContext()) {
+        if (isMavenVersionCheckEnabled && !runner.isVirtualContext()) {
             LOG.info("Running in non-virtual context.");
             final String mavenVersion = getMavenVersion(runner);
             LOG.info("Determined Maven version: " + mavenVersion);

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -215,14 +215,16 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private String getMavenInvocationArgs(BuildRunnerContext runner) {
         boolean isMavenVersionCheckEnabled = getBooleanConfigParam(IS_MAVEN_VERSION_CHECK_ENABLED_PARAM, runner);
 
-        // only check for the Maven version used by this build run in non-virtual environments since it cannot be checked reliably in virtual envs
-        if (isMavenVersionCheckEnabled && !runner.isVirtualContext()) {
-            LOG.info("Running in non-virtual context.");
-            final String mavenVersion = getMavenVersion(runner);
-            LOG.info("Determined Maven version: " + mavenVersion);
-            if (!isEmptyMavenVersion(mavenVersion) && !isMavenVersionAtLeast3_3_1(mavenVersion)) {
-                LOG.info("Cannot instrument Maven build with Gradle Enterprise. Gradle Enterprise Maven Extension is only supported for Maven 3.3.1 and higher.");
-                return "";
+        if (isMavenVersionCheckEnabled) {
+            // only check for the Maven version used by this build run in non-virtual environments since it cannot be checked reliably in virtual envs
+            if (!runner.isVirtualContext()) {
+                LOG.info("Running in non-virtual context.");
+                final String mavenVersion = getMavenVersion(runner);
+                LOG.info("Determined Maven version: " + mavenVersion);
+                if (!isEmptyMavenVersion(mavenVersion) && !isMavenVersionAtLeast3_3_1(mavenVersion)) {
+                    LOG.info("Cannot instrument Maven build with Gradle Enterprise. Gradle Enterprise Maven Extension is only supported for Maven 3.3.1 and higher.");
+                    return "";
+                }
             }
         }
 

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TcPluginConfig.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TcPluginConfig.groovy
@@ -12,6 +12,7 @@ class TcPluginConfig {
     String geExtensionCustomCoordinates
     String ccudExtensionCustomCoordinates
     boolean enableCommandLineRunner
+    boolean enableMavenVersionCheck
 
     // configuration params as they would be set by the user in the TeamCity configuration
     Map<String, String> toConfigParameters() {
@@ -45,6 +46,9 @@ class TcPluginConfig {
         }
         if (enableCommandLineRunner) {
             configProps.put 'buildScanPlugin.command-line-build-step.enabled', 'true'
+        }
+        if (enableMavenVersionCheck) {
+            configProps.put 'buildScanPlugin.maven-version-check.enabled', 'true'
         }
         configProps
     }

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
@@ -674,7 +674,7 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         def output = run(jdkCompatibleMavenVersion.mavenVersion, mvnProject, gePluginConfig, mvnBuildStepConfig)
 
         then:
-        assert output.contains("java.lang.NoClassDefFoundError: org/apache/maven/execution/MojoExecutionListener")
+        outputContainsNoClassDefFoundError(output)
 
         and:
         outputMissesTeamCityServiceMessageBuildStarted(output)
@@ -707,7 +707,7 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         def output = run(jdkCompatibleMavenVersion.mavenVersion, mvnProject, gePluginConfig, mvnBuildStepConfig)
 
         then:
-        assert output.contains("java.lang.NoClassDefFoundError: org/apache/maven/execution/MojoExecutionListener")
+        outputContainsNoClassDefFoundError(output)
 
         and:
         outputMissesTeamCityServiceMessageBuildStarted(output)
@@ -741,6 +741,10 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
 
     void outputContainsBuildSuccess(String output) {
         assert output.contains("[INFO] BUILD SUCCESS")
+    }
+
+    void outputContainsNoClassDefFoundError(String output) {
+        assert output.contains("java.lang.NoClassDefFoundError: org/apache/maven/execution/MojoExecutionListener")
     }
 
     static String getRelativePath(File parent, File child) {

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
@@ -625,6 +625,7 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         def gePluginConfig = new TcPluginConfig(
             geExtensionVersion: GE_EXTENSION_VERSION,
             ccudExtensionVersion: CCUD_EXTENSION_VERSION,
+            enableMavenVersionCheck: true,
         )
 
         and:
@@ -659,6 +660,7 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         def gePluginConfig = new TcPluginConfig(
             geExtensionVersion: GE_EXTENSION_VERSION,
             ccudExtensionVersion: CCUD_EXTENSION_VERSION,
+            enableMavenVersionCheck: true,
         )
 
         and:

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -16,6 +16,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String CUSTOM_GE_EXTENSION_COORDINATES = "customGradleEnterpriseExtensionCoordinates";
     public static final String CUSTOM_CCUD_EXTENSION_COORDINATES = "customCommonCustomUserDataExtensionCoordinates";
     public static final String INSTRUMENT_COMMAND_LINE_BUILD_STEP = "instrumentCommandLineBuildStep";
+    public static final String IS_MAVEN_VERSION_CHECK_ENABLED = "isMavenVersionCheckEnabled";
     public static final String GRADLE_ENTERPRISE_ACCESS_KEY = "gradleEnterpriseAccessKey";
 
     // Constants defined by the BuildScanServiceMessageInjector
@@ -31,6 +32,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String CUSTOM_GE_EXTENSION_COORDINATES_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.extension.custom.coordinates";
     public static final String CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM = "buildScanPlugin.ccud.extension.custom.coordinates";
     public static final String INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM = "buildScanPlugin.command-line-build-step.enabled";
+    public static final String IS_MAVEN_VERSION_CHECK_ENABLED_PARAM = "buildScanPlugin.maven-version-check.enabled";
     public static final String GRADLE_ENTERPRISE_ACCESS_KEY_ENV_VAR = "env.GRADLE_ENTERPRISE_ACCESS_KEY";
 
     public static final String GRADLE_ENTERPRISE_CONNECTION_PROVIDER = "gradle-enterprise-connection-provider";
@@ -81,4 +83,7 @@ public final class GradleEnterpriseConnectionConstants {
         return GRADLE_ENTERPRISE_ACCESS_KEY;
     }
 
+    public String getIsMavenVersionCheckEnabled() {
+        return IS_MAVEN_VERSION_CHECK_ENABLED;
+    }
 }

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -29,6 +29,7 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_ENTERPRISE_URL;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.IS_MAVEN_VERSION_CHECK_ENABLED;
 
 public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
 
@@ -121,6 +122,11 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
         String customCcudExtensionCoordinates = params.get(CUSTOM_CCUD_EXTENSION_COORDINATES);
         if (customCcudExtensionCoordinates != null) {
             description += String.format("* Common Custom User Data Maven Extension Custom Coordinates: %s\n", customCcudExtensionCoordinates);
+        }
+
+        String isMavenVersionCheckEnabled = params.get(IS_MAVEN_VERSION_CHECK_ENABLED);
+        if (isMavenVersionCheckEnabled != null) {
+            description += String.format("* Maven Version Check Enabled: %s\n", isMavenVersionCheckEnabled);
         }
 
         description += "\nTeamCity Build Steps Settings:\n";

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
@@ -37,6 +37,8 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.IS_MAVEN_VERSION_CHECK_ENABLED;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.IS_MAVEN_VERSION_CHECK_ENABLED_PARAM;
 
 /**
  * This implementation of {@link BuildParametersProvider} injects configuration parameters and environment variables
@@ -65,6 +67,7 @@ public final class GradleEnterpriseParametersProvider implements BuildParameters
             setParameter(CUSTOM_GE_EXTENSION_COORDINATES_CONFIG_PARAM, connectionParams.get(CUSTOM_GE_EXTENSION_COORDINATES), params);
             setParameter(CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM, connectionParams.get(CUSTOM_CCUD_EXTENSION_COORDINATES), params);
             setParameter(INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM, connectionParams.get(INSTRUMENT_COMMAND_LINE_BUILD_STEP), params);
+            setParameter(IS_MAVEN_VERSION_CHECK_ENABLED_PARAM, connectionParams.get(IS_MAVEN_VERSION_CHECK_ENABLED), params);
             setParameter(GRADLE_ENTERPRISE_ACCESS_KEY_ENV_VAR, connectionParams.get(GRADLE_ENTERPRISE_ACCESS_KEY), params);
         }
         return params;

--- a/src/main/resources/buildServerResources/geConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/geConnectionDialog.jsp
@@ -106,6 +106,14 @@
     </td>
 </tr>
 
+<tr class="advancedSetting">
+    <td><label for="${keys.isMavenVersionCheckEnabled}">Enable Maven Version Check:</label></td>
+    <td>
+        <props:checkboxProperty name="${keys.isMavenVersionCheckEnabled}"/>
+        <span class="smallNote">Enable a Maven version check to ensure that the Gradle Enterprise Maven Extension is not applied to Maven builds lower than version 3.3.1.</span>
+    </td>
+</tr>
+
 <tr class="groupingTitle">
     <td colspan="2">TeamCity Build Steps Settings</td>
 </tr>

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
@@ -17,6 +17,7 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_ENTERPRISE_URL
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.IS_MAVEN_VERSION_CHECK_ENABLED
 
 @Unroll
 class GradleEnterpriseConnectionProviderTest extends Specification {
@@ -65,6 +66,7 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         CCUD_EXTENSION_VERSION             | '1.11.1'                        | 'Common Custom User Data Maven Extension Version'
         CUSTOM_GE_EXTENSION_COORDINATES    | 'com.company:my-ge-extension'   | 'Gradle Enterprise Maven Extension Custom Coordinates'
         CUSTOM_CCUD_EXTENSION_COORDINATES  | 'com.company:my-ccud-extension' | 'Common Custom User Data Maven Extension Custom Coordinates'
+        IS_MAVEN_VERSION_CHECK_ENABLED     | 'false'                         | 'Maven Version Check Enabled'
         INSTRUMENT_COMMAND_LINE_BUILD_STEP | 'true'                          | 'Instrument Command Line Build Steps'
     }
 

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProviderTest.groovy
@@ -30,6 +30,8 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_ENTERPRISE_URL_CONFIG_PARAM
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.IS_MAVEN_VERSION_CHECK_ENABLED
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.IS_MAVEN_VERSION_CHECK_ENABLED_PARAM
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM
 
@@ -121,6 +123,7 @@ class GradleEnterpriseParametersProviderTest extends Specification {
         CUSTOM_GE_EXTENSION_COORDINATES    | CUSTOM_GE_EXTENSION_COORDINATES_CONFIG_PARAM    | '1.0.0'
         CUSTOM_CCUD_EXTENSION_COORDINATES  | CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM  | '1.0.0'
         INSTRUMENT_COMMAND_LINE_BUILD_STEP | INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM | 'true'
+        IS_MAVEN_VERSION_CHECK_ENABLED     | IS_MAVEN_VERSION_CHECK_ENABLED_PARAM            | 'false'
         GRADLE_ENTERPRISE_ACCESS_KEY       | GRADLE_ENTERPRISE_ACCESS_KEY_ENV_VAR            | 'ge.example.com=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     }
 


### PR DESCRIPTION
Adds a `buildScanPlugin.maven-version-check.enabled` parameter that enables the Maven version check to prevent applying the Gradle Enterprise Maven Extension to Maven builds less than version 3.3.1. By default, this check is not enabled.