### PR TITLE
Update test to apply latest GE plugin version

### DIFF
--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
@@ -147,7 +147,7 @@ class BaseInitScriptTest extends Specification {
         } else {
             """
               plugins {
-                id 'com.gradle.enterprise' version '3.4.1'
+                id 'com.gradle.enterprise' version '3.11.1'
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
               gradleEnterprise {
@@ -175,7 +175,7 @@ class BaseInitScriptTest extends Specification {
         } else if (gradleVersion < GradleVersion.version('6.0')) {
             """
               plugins {
-                id 'com.gradle.build-scan' version '3.4.1'
+                id 'com.gradle.build-scan' version '3.11.1'
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
               gradleEnterprise {


### PR DESCRIPTION
The tests for "GE plugin already applied" were applying an old version of the GE plugin (3.4.1). This was not causing test failures, but resulted in `Build scan background action failed.` messages in the test log output.

Updating to use the latest GE plugin (3.11.1) removes these error messages.