### PR TITLE
Add CI auto injection custom value and enable publishAlways for Maven

### DIFF
--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -243,7 +243,6 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
                 extensionJars.add(getExtensionJar(GRADLE_ENTERPRISE_EXT_MAVEN, runner));
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
-                addSysProp("scan.value.CI-auto-injection", "TeamCity", sysProps);
             }
         }
 
@@ -383,13 +382,9 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static void addSysPropIfSet(@NotNull String configParameter, @NotNull String property, List<String> sysProps, @NotNull BuildRunnerContext runner) {
         String value = getOptionalConfigParam(configParameter, runner);
         if (value != null) {
-            addSysProp(property, value, sysProps);
+            String sysProp = String.format("-D%s=%s", property, value);
+            sysProps.add(sysProp);
         }
-    }
-
-    private static void addSysProp(@NotNull String property, String value, List<String> sysProps) {
-        String sysProp = String.format("-D%s=%s", property, value);
-        sysProps.add(sysProp);
     }
 
     private static void addMavenCmdParam(@NotNull String param, @NotNull BuildRunnerContext runner) {

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -243,7 +243,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
                 extensionJars.add(getExtensionJar(GRADLE_ENTERPRISE_EXT_MAVEN, runner));
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
-                addSysProp("scan.value.CIAutoInjection", "TeamCity", sysProps);
+                addSysProp("scan.value.CI-auto-injection", "TeamCity", sysProps);
             }
         }
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -243,6 +243,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
                 extensionJars.add(getExtensionJar(GRADLE_ENTERPRISE_EXT_MAVEN, runner));
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
+                addSysProp("scan.value.CIAutoInjection", "TeamCity", sysProps);
             }
         }
 
@@ -382,9 +383,13 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static void addSysPropIfSet(@NotNull String configParameter, @NotNull String property, List<String> sysProps, @NotNull BuildRunnerContext runner) {
         String value = getOptionalConfigParam(configParameter, runner);
         if (value != null) {
-            String sysProp = String.format("-D%s=%s", property, value);
-            sysProps.add(sysProp);
+            addSysProp(property, value, sysProps);
         }
+    }
+
+    private static void addSysProp(@NotNull String property, String value, List<String> sysProps) {
+        String sysProp = String.format("-D%s=%s", property, value);
+        sysProps.add(sysProp);
     }
 
     private static void addMavenCmdParam(@NotNull String param, @NotNull BuildRunnerContext runner) {

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -118,7 +118,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
-                    buildScan.value 'CIAutoInjection', 'TeamCity'
+                    buildScan.value 'CI-auto-injection', 'TeamCity'
                 }
             }
 
@@ -148,7 +148,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     ext.buildScan.publishAlways()
-                    ext.buildScan.value 'CIAutoInjection', 'TeamCity'
+                    ext.buildScan.value 'CI-auto-injection', 'TeamCity'
                 }
             }
         }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -118,7 +118,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
-                    buildScan.value 'CI auto injection', 'TeamCity'
+                    buildScan.value 'CIAutoInjection', 'TeamCity'
                 }
             }
 
@@ -148,7 +148,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     ext.buildScan.publishAlways()
-                    ext.buildScan.value 'CI auto injection', 'TeamCity'
+                    ext.buildScan.value 'CIAutoInjection', 'TeamCity'
                 }
             }
         }


### PR DESCRIPTION
Should we now rename the service-message-maven-extension to something more generic now that we use it for configuring the BuildScanApi too?