### PR TITLE
Update default version of Gradle Enterprise Gradle plugin to 3.12

### DIFF
--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
-gradleEnterprisePluginVersion=3.11.4
+gradleEnterprisePluginVersion=3.12
 commonCustomUserDataPluginVersion=1.8.2
 gradleEnterpriseExtensionVersion=1.15.5
 commonCustomUserDataExtensionVersion=1.11.1


### PR DESCRIPTION
Note: There are still quite a few references to 3.11.4 (e.g. in tests). Please let me know if I should upgrade those as well. 