### PR TITLE
Update usages of Gradle Enterprise Maven extension to 1.16

### DIFF
--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -42,7 +42,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String MAVEN_RUNNER = "Maven2";
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";
     private static final String BUILD_SCAN_EXT_MAVEN = "service-message-maven-extension-1.0.jar";
-    private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.15.5.jar";
+    private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.16.jar";
     private static final String COMMON_CUSTOM_USER_DATA_EXT_MAVEN = "common-custom-user-data-maven-extension-1.11.1.jar";
 
     // TeamCity Command-line runner

--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
 gradleEnterprisePluginVersion=3.11.4
 commonCustomUserDataPluginVersion=1.8.2
-gradleEnterpriseExtensionVersion=1.15.5
+gradleEnterpriseExtensionVersion=1.16
 commonCustomUserDataExtensionVersion=1.11.1


### PR DESCRIPTION
Note: There are still many references to 1.15.5. Please let me know if I should upgrade those as well.