### PR TITLE
Disable Upload Scan in Background

### DIFF
--- a/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
+++ b/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageMavenExtension.java
@@ -33,6 +33,8 @@ public final class BuildScanServiceMessageMavenExtension implements GradleEnterp
             BuildScanServiceMessageSender.register(api.getBuildScan());
             logger.debug("Finished registering listener capturing build scan link");
         }
+
+        api.getBuildScan().setUploadInBackground(false);
     }
 
     private static boolean invokesJetBrainsInfoGoal(MavenSession session) {

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -118,8 +118,12 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
-                    buildScan.uploadInBackground = false
                     buildScan.value 'CI auto injection', 'TeamCity'
+
+                    // uploadInBackground not available for build-scan-plugin 1.16
+                    if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) {
+                        buildScan.uploadInBackground = false
+                    }
                 }
             }
 

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -118,6 +118,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
+                    buildScan.uploadInBackground = false
                     buildScan.value 'CI auto injection', 'TeamCity'
                 }
             }
@@ -148,6 +149,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     ext.buildScan.publishAlways()
+                    ext.buildScan.uploadInBackground = false
                     ext.buildScan.value 'CI auto injection', 'TeamCity'
                 }
             }


### PR DESCRIPTION
Since all builds instrumented by this plugin are CI builds, always set `UploadInBackground` for both Maven and Gradle builds.

Fixes https://github.com/etiennestuder/teamcity-build-scan-plugin/issues/166