### PR TITLE
Support configuration cached builds

### DIFF
--- a/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageSender.java
+++ b/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageSender.java
@@ -5,15 +5,9 @@ import com.gradle.maven.extension.api.scan.BuildScanApi;
 final class BuildScanServiceMessageSender {
 
     private static final String BUILD_SCAN_SERVICE_MESSAGE_NAME = "nu.studer.teamcity.buildscan.buildScanLifeCycle";
-    private static final String BUILD_SCAN_SERVICE_STARTED_MESSAGE_ARGUMENT = "BUILD_STARTED";
     private static final String BUILD_SCAN_SERVICE_URL_MESSAGE_ARGUMENT_PREFIX = "BUILD_SCAN_URL:";
 
     static void register(BuildScanApi buildScan) {
-        System.out.println(ServiceMessage.of(
-            BUILD_SCAN_SERVICE_MESSAGE_NAME,
-            BUILD_SCAN_SERVICE_STARTED_MESSAGE_ARGUMENT
-        ));
-
         buildScan.buildScanPublished(publishedBuildScan ->
             System.out.println(ServiceMessage.of(
                 BUILD_SCAN_SERVICE_MESSAGE_NAME,

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -90,13 +90,14 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
 }
 
 // send a message to the server that the build has started
-logger.quiet(generateBuildScanLifeCycleMessage('BUILD_STARTED'))
+logger.quiet(BuildScanLifeCycleLogger.generateBuildScanLifeCycleMessage('BUILD_STARTED'))
 
 // define a buildScanPublished listener that captures the build scan URL and sends it in a message to the server
+def buildScanLifeCycleLogger = new BuildScanLifeCycleLogger(logger)
 def buildScanPublishedAction = { def buildScan ->
     if (buildScan.metaClass.respondsTo(buildScan, 'buildScanPublished', Action)) {
         buildScan.buildScanPublished { scan ->
-            logger.quiet(generateBuildScanLifeCycleMessage("BUILD_SCAN_URL:${scan.buildScanUri.toString()}"))
+            buildScanLifeCycleLogger.log("BUILD_SCAN_URL:${scan.buildScanUri.toString()}")
         }
     }
 }
@@ -170,28 +171,39 @@ static def extensionsWithPublicType(def container, String publicType) {
     container.extensions.extensionsSchema.elements.findAll { it.publicType.concreteClass.name == publicType }
 }
 
-static String generateBuildScanLifeCycleMessage(def attribute) {
-    return "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle '${escape(attribute as String)}']" as String
-}
-
-static String escape(String value) {
-    return value?.toCharArray()?.collect { ch -> escapeChar(ch) }?.join()
-}
-
-static String escapeChar(char ch) {
-    String escapeCharacter = "|"
-    switch (ch) {
-        case '\n': return escapeCharacter + "n"
-        case '\r': return escapeCharacter + "r"
-        case '|': return escapeCharacter + "|"
-        case '\'': return escapeCharacter + "\'"
-        case '[': return escapeCharacter + "["
-        case ']': return escapeCharacter + "]"
-        default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int) ch)
-    }
-}
-
 static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
     GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
 }
 
+class BuildScanLifeCycleLogger {
+    def logger
+
+    BuildScanLifeCycleLogger(logger) {
+        this.logger = logger
+    }
+
+    void log(String message) {
+        logger.log(generateBuildScanLifeCycleMessage(message))
+    }
+
+    static String generateBuildScanLifeCycleMessage(def attribute) {
+        return "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle '${escape(attribute as String)}']" as String
+    }
+
+    static String escape(String value) {
+        return value?.toCharArray()?.collect { ch -> escapeChar(ch) }?.join()
+    }
+
+    static String escapeChar(char ch) {
+        String escapeCharacter = "|"
+        switch (ch) {
+            case '\n': return escapeCharacter + "n"
+            case '\r': return escapeCharacter + "r"
+            case '|': return escapeCharacter + "|"
+            case '\'': return escapeCharacter + "\'"
+            case '[': return escapeCharacter + "["
+            case ']': return escapeCharacter + "]"
+            default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int) ch)
+        }
+    }
+}

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -89,9 +89,6 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
     return
 }
 
-// send a message to the server that the build has started
-logger.quiet(BuildScanLifeCycleLogger.generateBuildScanLifeCycleMessage('BUILD_STARTED'))
-
 // define a buildScanPublished listener that captures the build scan URL and sends it in a message to the server
 def buildScanLifeCycleLogger = new BuildScanLifeCycleLogger(logger)
 def buildScanPublishedAction = { def buildScan ->

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
@@ -251,12 +251,6 @@ class BaseInitScriptTest extends Specification {
         }
     }
 
-    void outputContainsTeamCityServiceMessageBuildStarted(BuildResult result) {
-        def serviceMsg = "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_STARTED']"
-        assert result.output.contains(serviceMsg)
-        assert 1 == result.output.count(serviceMsg)
-    }
-
     void outputContainsTeamCityServiceMessageBuildScanUrl(BuildResult result) {
         def serviceMsg = "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_SCAN_URL:${mockScansServer.address}s/$PUBLIC_BUILD_SCAN_ID']"
         assert result.output.contains(serviceMsg)

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
@@ -61,6 +61,9 @@ class BaseInitScriptTest extends Specification {
     static final List<JdkCompatibleGradleVersion> GRADLE_VERSIONS_4_AND_HIGHER =
         GRADLE_VERSIONS_3_5_AND_HIGHER - [GRADLE_3_5]
 
+    static final List<JdkCompatibleGradleVersion> CONFIGURATION_CACHE_COMPATIBLE_GRADLE_VERSIONS =
+        GRADLE_VERSIONS_4_AND_HIGHER.findAll { it.gradleVersion >= GradleVersion.version('6.9') }
+
     static final String PUBLIC_BUILD_SCAN_ID = 'i2wepy2gr7ovw'
     static final String DEFAULT_SCAN_UPLOAD_TOKEN = 'scan-upload-token'
 

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BuildScanUrlCapturingTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BuildScanUrlCapturingTest.groovy
@@ -4,19 +4,6 @@ import static org.junit.Assume.assumeTrue
 
 class BuildScanUrlCapturingTest extends BaseInitScriptTest {
 
-    def "sends build started service message even without declaring Gradle Enterprise / Build Scan plugin (#jdkCompatibleGradleVersion)"() {
-        assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
-
-        when:
-        def result = run(jdkCompatibleGradleVersion.gradleVersion)
-
-        then:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
-
-        where:
-        jdkCompatibleGradleVersion << GRADLE_VERSIONS_2_AND_HIGHER
-    }
-
     def "send build scan url service message when declaring Gradle Enterprise / Build Scan plugin (#jdkCompatibleGradleVersion)"() {
         assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
 
@@ -27,7 +14,6 @@ class BuildScanUrlCapturingTest extends BaseInitScriptTest {
         def result = run(jdkCompatibleGradleVersion.gradleVersion)
 
         then:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GradleEnterprisePluginApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GradleEnterprisePluginApplicationTest.groovy
@@ -273,6 +273,33 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         jdkCompatibleGradleVersion << GRADLE_VERSIONS_2_AND_HIGHER
     }
 
+    def "is configuration cache compatible (#jdkCompatibleGradleVersion)"() {
+        assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
+
+        when:
+        def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, gePluginVersion: GE_PLUGIN_VERSION)
+        def config = new BuildConfig(
+            gradleVersion: jdkCompatibleGradleVersion.gradleVersion,
+            tcPluginConfig: gePluginConfig,
+            additionalJvmArgs: ["-Dorg.gradle.unsafe.configuration-cache=true"])
+        def result = run(config)
+
+        then:
+        outputContainsTeamCityServiceMessageBuildStarted(result)
+        outputContainsTeamCityServiceMessageBuildScanUrl(result)
+
+        when:
+        result = run(config)
+
+        then:
+        outputContainsTeamCityServiceMessageBuildStarted(result)
+        outputContainsTeamCityServiceMessageBuildScanUrl(result)
+
+        where:
+        // Scoped to 7.2+ due to https://github.com/gradle/gradle/issues/17340
+        jdkCompatibleGradleVersion << CONFIGURATION_CACHE_COMPATIBLE_GRADLE_VERSIONS.findAll { it.gradleVersion >= GradleVersion.version('7.2') }
+    }
+
     void outputContainsGePluginApplicationViaInitScript(BuildResult result, GradleVersion gradleVersion) {
         def pluginApplicationLogMsgGradle4And5 = "Applying com.gradle.scan.plugin.BuildScanPlugin via init script"
         def pluginApplicationLogMsgGradle6AndHigher = "Applying com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin via init script"

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GradleEnterprisePluginApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GradleEnterprisePluginApplicationTest.groovy
@@ -24,9 +24,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputMissesGePluginApplicationViaInitScript(result)
         outputMissesCcudPluginApplicationViaInitScript(result)
 
-        and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
-
         where:
         jdkCompatibleGradleVersion << GRADLE_VERSIONS_2_AND_HIGHER
     }
@@ -43,7 +40,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputMissesCcudPluginApplicationViaInitScript(result)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:
@@ -65,7 +61,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputMissesCcudPluginApplicationViaInitScript(result)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:
@@ -84,7 +79,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputContainsCcudPluginApplicationViaInitScript(result)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:
@@ -106,7 +100,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputContainsCcudPluginApplicationViaInitScript(result)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:
@@ -128,7 +121,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputMissesCcudPluginApplicationViaInitScript(result)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:
@@ -150,7 +142,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputMissesCcudPluginApplicationViaInitScript(result)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:
@@ -171,7 +162,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputContainsPluginRepositoryInfo(result, 'https://plugins.gradle.org/m2')
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:
@@ -226,7 +216,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputContainsCcudPluginApplicationViaInitScript(result)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:
@@ -266,7 +255,6 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         outputMissesCcudPluginApplicationViaInitScript(result)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:
@@ -285,14 +273,12 @@ class GradleEnterprisePluginApplicationTest extends BaseInitScriptTest {
         def result = run(config)
 
         then:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         when:
         result = run(config)
 
         then:
-        outputContainsTeamCityServiceMessageBuildStarted(result)
         outputContainsTeamCityServiceMessageBuildScanUrl(result)
 
         where:

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
@@ -29,7 +29,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputMissesTeamCityServiceMessageBuildStarted(output)
         outputMissesTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -57,7 +56,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -88,7 +86,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -121,7 +118,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -158,7 +154,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -191,7 +186,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -224,7 +218,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputMissesTeamCityServiceMessageBuildStarted(output)
         outputMissesTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -252,7 +245,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         1 * extensionApplicationListener.ccudExtensionApplied(CCUD_EXTENSION_VERSION)
 
         and:
-        outputMissesTeamCityServiceMessageBuildStarted(output)
         outputMissesTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -281,7 +273,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         1 * extensionApplicationListener.ccudExtensionApplied(CCUD_EXTENSION_VERSION)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -313,7 +304,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         1 * extensionApplicationListener.ccudExtensionApplied(CCUD_EXTENSION_VERSION)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -346,7 +336,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -380,7 +369,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -412,7 +400,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -444,7 +431,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         0 * extensionApplicationListener.ccudExtensionApplied(_)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -474,7 +460,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         def output = run(jdkCompatibleMavenVersion.mavenVersion, mvnProject, gePluginConfig, mvnBuildStepConfig)
 
         then:
-        outputMissesTeamCityServiceMessageBuildStarted(output)
         outputMissesTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -498,7 +483,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
 
         then:
         outputContainsBuildSuccess(output)
-        outputMissesTeamCityServiceMessageBuildStarted(output)
         outputMissesTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -534,7 +518,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         outputContainsBuildSuccess(output)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -570,7 +553,6 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         outputContainsBuildSuccess(output)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
@@ -607,22 +589,10 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
         outputContainsBuildSuccess(output)
 
         and:
-        outputContainsTeamCityServiceMessageBuildStarted(output)
         outputContainsTeamCityServiceMessageBuildScanUrl(output)
 
         where:
         jdkCompatibleMavenVersion << SUPPORTED_MAVEN_VERSIONS
-    }
-
-    void outputContainsTeamCityServiceMessageBuildStarted(String output) {
-        def serviceMsg = "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_STARTED']"
-        assert output.contains(serviceMsg)
-        assert 1 == output.count(serviceMsg)
-    }
-
-    void outputMissesTeamCityServiceMessageBuildStarted(String output) {
-        def serviceMsg = "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle 'BUILD_STARTED']"
-        assert !output.contains(serviceMsg)
     }
 
     void outputContainsTeamCityServiceMessageBuildScanUrl(String output) {

--- a/src/main/java/nu/studer/teamcity/buildscan/BuildScanBuildServerListener.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/BuildScanBuildServerListener.java
@@ -7,15 +7,21 @@ import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+
 public final class BuildScanBuildServerListener extends BuildServerAdapter {
 
     private static final Logger LOGGER = Logger.getLogger("jetbrains.buildServer.BUILDSCAN");
+    private static final String GRADLE_RUNNER = "gradle-runner";
+    private static final String MAVEN_RUNNER = "Maven2";
+    private static final String COMMAND_LINE_RUNNER = "simpleRunner";
 
     private final PluginDescriptor pluginDescriptor;
     private final SBuildServer buildServer;
     private final BuildScanDisplayArbiter buildScanDisplayArbiter;
     private final BuildScanLookup buildScanLookup;
     private final ExternalIntegration externalIntegration;
+    private final BuildScanDataStore buildScanDataStore;
 
     @SuppressWarnings("WeakerAccess")
     public BuildScanBuildServerListener(
@@ -23,13 +29,15 @@ public final class BuildScanBuildServerListener extends BuildServerAdapter {
         @NotNull SBuildServer buildServer,
         @NotNull BuildScanDisplayArbiter buildScanDisplayArbiter,
         @NotNull BuildScanLookup buildScanLookup,
-        @NotNull ExternalIntegration externalIntegration
+        @NotNull ExternalIntegration externalIntegration,
+        @NotNull BuildScanDataStore buildScanDataStore
     ) {
         this.pluginDescriptor = pluginDescriptor;
         this.buildServer = buildServer;
         this.buildScanDisplayArbiter = buildScanDisplayArbiter;
         this.buildScanLookup = buildScanLookup;
         this.externalIntegration = externalIntegration;
+        this.buildScanDataStore = buildScanDataStore;
     }
 
     @SuppressWarnings("unused")
@@ -42,6 +50,16 @@ public final class BuildScanBuildServerListener extends BuildServerAdapter {
     public void unregister() {
         buildServer.removeListener(this);
         LOGGER.info(String.format("Unregistered %s. %s-%s", getClass().getSimpleName(), pluginDescriptor.getPluginName(), pluginDescriptor.getPluginVersion()));
+    }
+
+    @Override
+    public void buildStarted(@NotNull SRunningBuild build) {
+        if (build.getBuildType() != null) {
+            Collection<String> runnerTypes = build.getBuildType().getRunnerTypes();
+            if (runnerTypes.contains(GRADLE_RUNNER) || runnerTypes.contains(MAVEN_RUNNER) || runnerTypes.contains(COMMAND_LINE_RUNNER)) {
+                buildScanDataStore.mark(build);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/nu/studer/teamcity/buildscan/internal/BuildScanServiceMessageListener.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/internal/BuildScanServiceMessageListener.java
@@ -19,7 +19,6 @@ public final class BuildScanServiceMessageListener implements ServiceMessageTran
 
     // values need to be kept in sync with build-scan-init.gradle
     private static final String BUILD_SCAN_SERVICE_MESSAGE_NAME = "nu.studer.teamcity.buildscan.buildScanLifeCycle";
-    private static final String BUILD_SCAN_SERVICE_STARTED_MESSAGE_ARGUMENT = "BUILD_STARTED";
     private static final String BUILD_SCAN_SERVICE_URL_MESSAGE_ARGUMENT_PREFIX = "BUILD_SCAN_URL:";
 
     private final BuildScanDataStore buildScanDataStore;
@@ -32,9 +31,7 @@ public final class BuildScanServiceMessageListener implements ServiceMessageTran
     @Override
     public List<BuildMessage1> translate(@NotNull SRunningBuild runningBuild, @NotNull BuildMessage1 originalMessage, @NotNull ServiceMessage serviceMessage) {
         String argument = requireNonNull(serviceMessage.getArgument());
-        if (argument.equals(BUILD_SCAN_SERVICE_STARTED_MESSAGE_ARGUMENT)) {
-            buildScanDataStore.mark(runningBuild);
-        } else if (argument.startsWith(BUILD_SCAN_SERVICE_URL_MESSAGE_ARGUMENT_PREFIX)) {
+        if (argument.startsWith(BUILD_SCAN_SERVICE_URL_MESSAGE_ARGUMENT_PREFIX)) {
             buildScanDataStore.store(runningBuild, argument.substring(BUILD_SCAN_SERVICE_URL_MESSAGE_ARGUMENT_PREFIX.length()));
         } else {
             LOGGER.error(String.format("Unknown argument format: '%s' for message service: %s", argument, BUILD_SCAN_SERVICE_MESSAGE_NAME));


### PR DESCRIPTION
Fixes https://github.com/etiennestuder/teamcity-build-scan-plugin/issues/160

This PR modifies the init script to allow printing of the build scan url in scenarios where a configuration cache entry is reused. To handle the build started message, the logic is moved into the server components to react to TeamCity APIs for the start of the build.