### PR TITLE
Force `createReleaseTag` to run after `check`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,9 +101,10 @@ repositories {
     mavenCentral()
 }
 
-tasks.register('createReleaseTag', CreateGitTag) {
+tasks.register('createReleaseTag', CreateGitTag) { createGitTag ->
     tagName = gitReleaseTag()
     overwriteExisting = !RELEASE
+    allprojects { createGitTag.mustRunAfter(it.tasks.named("check")) }
 }
 
 tasks.named('githubRelease') {


### PR DESCRIPTION
This ensures that for release actions, artifacts will not be produced when tests fail. Fixes #171 