### PR TITLE
Bump Maven Wrapper from 3.8.6 to 3.8.7 in /agent/service-message-maven-extension

### DIFF
--- a/agent/service-message-maven-extension/.mvn/wrapper/maven-wrapper.properties
+++ b/agent/service-message-maven-extension/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.7/apache-maven-3.8.7-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar


### PR DESCRIPTION
Bumps Maven Wrapper from 3.8.6 to 3.8.7.

Release notes of Maven 3.8.7 can be found here:
https://maven.apache.org/docs/3.8.7/release-notes.html