### PR TITLE
Bump Gradle Enterprise Maven Extension version to 1.16.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ For Maven builds, the version of the Gradle Enterprise Maven extension automatic
 
 | TC Build Scan plugin version | Injected GE Maven extension version | Injected Common CCUD Maven extension version |
 |------------------------------|-------------------------------------|----------------------------------------------|
-| Next                         | 1.16.4                              | 1.11.1                                       |
+| Next                         | 1.16.5                              | 1.11.1                                       |
 | 0.33                         | 1.16.1                              | 1.11.1                                       |
 | 0.32                         | 1.15.4                              | 1.11.1                                       |
 | 0.31                         | 1.15.3                              | 1.11.1                                       |

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -16,7 +16,7 @@ configurations {
 
 dependencies {
     mvnExtensions project(path: ':agent:service-message-maven-extension', configuration: 'mvnExtension')
-    mvnExtensions 'com.gradle:gradle-enterprise-maven-extension:1.16.4'
+    mvnExtensions 'com.gradle:gradle-enterprise-maven-extension:1.16.5'
     mvnExtensions 'com.gradle:common-custom-user-data-maven-extension:1.11.1'
 
     testImplementation gradleTestKit()

--- a/agent/service-message-maven-extension/.mvn/extensions.xml
+++ b/agent/service-message-maven-extension/.mvn/extensions.xml
@@ -3,7 +3,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.16.4</version>
+        <version>1.16.5</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>

--- a/agent/service-message-maven-extension/pom.xml
+++ b/agent/service-message-maven-extension/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>gradle-enterprise-maven-extension</artifactId>
-            <version>1.16.4</version>
+            <version>1.16.5</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -42,7 +42,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String MAVEN_RUNNER = "Maven2";
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";
     private static final String BUILD_SCAN_EXT_MAVEN = "service-message-maven-extension-1.0.jar";
-    private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.16.4.jar";
+    private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.16.5.jar";
     private static final String COMMON_CUSTOM_USER_DATA_EXT_MAVEN = "common-custom-user-data-maven-extension-1.11.1.jar";
 
     // TeamCity Command-line runner

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/GradleEnterpriseExtensionApplicationTest.groovy
@@ -8,7 +8,7 @@ class GradleEnterpriseExtensionApplicationTest extends BaseExtensionApplicationT
 
     static final String GE_URL_STR = System.getenv('GRADLE_ENTERPRISE_TEST_INSTANCE')
     static final URI GE_URL = GE_URL_STR ? new URI(GE_URL_STR) : null
-    static final String GE_EXTENSION_VERSION = '1.16.4'
+    static final String GE_EXTENSION_VERSION = '1.16.5'
     static final String CCUD_EXTENSION_VERSION = '1.11.1'
 
     def "does not apply GE / CCUD extensions when not defined in project and not requested via TC config (#jdkCompatibleMavenVersion)"() {

--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
 gradleEnterprisePluginVersion=3.12.3
 commonCustomUserDataPluginVersion=1.8.2
-gradleEnterpriseExtensionVersion=1.16.4
+gradleEnterpriseExtensionVersion=1.16.5
 commonCustomUserDataExtensionVersion=1.11.1

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
@@ -61,7 +61,7 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         ALLOW_UNTRUSTED_SERVER             | 'true'                          | 'Allow Untrusted Server'
         GE_PLUGIN_VERSION                  | '3.12.3'                        | 'Gradle Enterprise Gradle Plugin Version'
         CCUD_PLUGIN_VERSION                | '1.8.2'                         | 'Common Custom User Data Gradle Plugin Version'
-        GE_EXTENSION_VERSION               | '1.16.4'                        | 'Gradle Enterprise Maven Extension Version'
+        GE_EXTENSION_VERSION               | '1.16.5'                        | 'Gradle Enterprise Maven Extension Version'
         CCUD_EXTENSION_VERSION             | '1.11.1'                        | 'Common Custom User Data Maven Extension Version'
         CUSTOM_GE_EXTENSION_COORDINATES    | 'com.company:my-ge-extension'   | 'Gradle Enterprise Maven Extension Custom Coordinates'
         CUSTOM_CCUD_EXTENSION_COORDINATES  | 'com.company:my-ccud-extension' | 'Common Custom User Data Maven Extension Custom Coordinates'


### PR DESCRIPTION
This PR bumps the Gradle Enterprise Gradle plugin version from 1.16.4 to 1.16.5.