### PR TITLE
Validate Gradle Enterptise access token

### DIFF
--- a/src/main/java/nu/studer/teamcity/buildscan/internal/GradleEnterpriseAccessKeyValidator.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/internal/GradleEnterpriseAccessKeyValidator.java
@@ -1,0 +1,39 @@
+package nu.studer.teamcity.buildscan.internal;
+
+import com.google.common.base.Strings;
+
+public final class GradleEnterpriseAccessKeyValidator {
+
+    private GradleEnterpriseAccessKeyValidator() {
+    }
+
+    public static boolean isValid(String value) {
+        if (Strings.isNullOrEmpty(value)) {
+            return false;
+        }
+
+        String[] entries = value.split(";");
+
+        for (String entry : entries) {
+            String[] parts = entry.split("=", 2);
+            if (parts.length < 2) {
+                return false;
+            }
+
+            String servers = parts[0];
+            String accessKey = parts[1];
+
+            if (Strings.isNullOrEmpty(servers) || Strings.isNullOrEmpty(accessKey)) {
+                return false;
+            }
+
+            for (String server : servers.split(",")) {
+                if (Strings.isNullOrEmpty(server)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/resources/META-INF/build-server-plugin-buildscans.xml
+++ b/src/main/resources/META-INF/build-server-plugin-buildscans.xml
@@ -63,15 +63,15 @@
     </bean>
 
     <bean id="gradleEnterpriseConnectionProvider"
-          class = "nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionProvider">
+          class="nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionProvider">
     </bean>
 
     <bean id="gradleEnterpriseParametersProvider"
-          class = "nu.studer.teamcity.buildscan.connection.GradleEnterpriseParametersProvider">
+          class="nu.studer.teamcity.buildscan.connection.GradleEnterpriseParametersProvider">
     </bean>
 
     <bean id="gradleEnterprisePasswordProvider"
-          class = "nu.studer.teamcity.buildscan.connection.GradleEnterprisePasswordProvider">
+          class="nu.studer.teamcity.buildscan.connection.GradleEnterprisePasswordProvider">
     </bean>
 
 </beans>

--- a/src/main/resources/buildServerResources/geConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/geConnectionDialog.jsp
@@ -37,7 +37,14 @@
     <td><label for="${keys.gradleEnterpriseAccessKey}">Gradle Enterprise Access Key:</label></td>
     <td>
         <props:passwordProperty name="${keys.gradleEnterpriseAccessKey}" className="longField"/>
+        <span class="error" id="error_${keys.gradleEnterpriseAccessKey}"></span>
         <span class="smallNote">The access key for authenticating with the Gradle Enterprise server.</span>
+    </td>
+</tr>
+
+<tr>
+    <td colspan="2">
+        <div class="smallNoteAttention">The access key must be in the <b>&lt;server host name&gt;=&lt;access key&gt;</b> format. For more details please refer to the <a href="https://docs.gradle.com/enterprise/gradle-plugin/#manual_access_key_configuration" target="_blank">documentation</a>.</div>
     </td>
 </tr>
 

--- a/src/test/groovy/nu/studer/teamcity/buildscan/internal/GradleEnterpriseAccessKeyValidatorTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/internal/GradleEnterpriseAccessKeyValidatorTest.groovy
@@ -1,0 +1,47 @@
+package nu.studer.teamcity.buildscan.internal
+
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+@Unroll
+@Subject(GradleEnterpriseAccessKeyValidator)
+class GradleEnterpriseAccessKeyValidatorTest extends Specification {
+
+    def "valid access key: #accessKey"() {
+        expect:
+        GradleEnterpriseAccessKeyValidator.isValid(accessKey)
+
+        where:
+        accessKey << [
+            'server=secret',
+            'server=secret ',
+            'server = secret',
+            ' server= secret',
+
+            'sever1,server2,server3=secret',
+            ' sever1, server2 , server3 = secret ',
+
+            'server1=secret1;server2=secret2;server3=secret3',
+            ' server1= secret1; server2 , sever3 = secret2 ;'
+        ]
+    }
+
+    def "invalid access key: #accessKey"() {
+        expect:
+        !GradleEnterpriseAccessKeyValidator.isValid(accessKey)
+
+        where:
+        accessKey << [
+            null,
+            '',
+            ' ',
+            'server=',
+            '=secret',
+            'secret',
+            'server=secret; ',
+            ';server=secret',
+            'server1, server2,, server3 = secret '
+        ]
+    }
+}


### PR DESCRIPTION
This PR improves the UX of the connection form by adding information about the expected format of the access key:

<img width="621" alt="Screenshot 2023-03-06 at 17 55 22" src="https://user-images.githubusercontent.com/1210272/223178840-fe9b2ccc-170c-49cb-82ea-3d5128b9e0e7.png">

The access key is validated on the server and in case it is not valid the form is rejected with the error message:

<img width="614" alt="Screenshot 2023-03-06 at 17 55 47" src="https://user-images.githubusercontent.com/1210272/223179431-37fabe12-9c73-4cf1-95d5-bf83fe87bb4c.png">

