### PR TITLE
Gradle Enterprise server URL is overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ A Gradle Enterprise connection can be created on any project and is automaticall
 
 <summary>Click for an example configuration.</summary>
 
-<img width="591" alt="gradle-enterprise-connection-dialog" src="https://user-images.githubusercontent.com/30589784/197518847-cc3c3e55-d298-4f2c-889d-53d414e87ff2.png">
+<img width="591" alt="gradle-enterprise-connection-dialog" src="https://user-images.githubusercontent.com/625514/235496130-06c0934b-936f-4a43-aad0-605f19c12219.png">
 
 </details>
 
@@ -104,6 +104,7 @@ The TeamCity configuration parameters can be set on any project and are automati
 2. If required, provide additional configuration parameters for your environment (optional):
 
     - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Gradle Enterprise instance is using a self-signed certificate
+    - `buildScanPlugin.gradle-enterprise.override-existing-server` - override the existing server defined in the project; set to _true_ to force build scans to publish to the url specified in TeamCity
     - `buildScanPlugin.gradle.plugin-repository.url` - the URL of the repository to use when resolving the GE and CCUD plugins; required if your TeamCity agents are not able to access the Gradle Plugin Portal
     - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for _Command Line_ build steps; by default only steps using the _Gradle_ runner are enabled
 
@@ -122,6 +123,7 @@ The TeamCity configuration parameters can be set on any project and are automati
 2. If required, provide additional configuration parameters for your environment (optional):
 
     - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Gradle Enterprise instance is using a self-signed certificate
+    - `buildScanPlugin.gradle-enterprise.override-existing-server` - override the existing server defined in the project; set to _true_ to force build scans to publish to the url specified in TeamCity
     - `buildScanPlugin.gradle-enterprise.extension.custom.coordinates` - the coordinates of a custom extension that has a transitive dependency on the Gradle Enterprise Maven Extension
     - `buildScanPlugin.ccud.extension.custom.coordinates` - the coordinates of a custom Common Custom User Data Maven Extension or of a custom extension that has a transitive dependency on it
     - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for _Command Line_ build steps; by default only steps using the _Maven_ runner are enabled

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ A Gradle Enterprise connection can be created on any project and is automaticall
 
 <summary>Click for an example configuration.</summary>
 
-<img width="591" alt="gradle-enterprise-connection-dialog" src="https://user-images.githubusercontent.com/625514/235496130-06c0934b-936f-4a43-aad0-605f19c12219.png">
+<img width="591" alt="gradle-enterprise-connection-dialog" src="https://user-images.githubusercontent.com/625514/235716524-ef39e577-07d2-4ceb-9dfd-de515aff3d3d.png">
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ The TeamCity configuration parameters can be set on any project and are automati
 
 1. In TeamCity, on the build configuration for which you want to apply Gradle Enterprise, create three configuration parameters:
 
-   - `buildScanPlugin.gradle-enterprise.url` - the URL of the Gradle Enterprise instance to which to publish the Build Scan
+   - `buildScanPlugin.gradle-enterprise.url` - the URL of the Gradle Enterprise instance to which to publish build scans
    - `buildScanPlugin.gradle-enterprise.plugin.version` - the version of the [Gradle Enterprise Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) to apply
    - `buildScanPlugin.ccud.plugin.version` - the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply (optional)
 
 2. If required, provide additional configuration parameters for your environment (optional):
 
     - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Gradle Enterprise instance is using a self-signed certificate
-    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Gradle Enterprise URL over a URL configured by the project; set to _true_ to force build scans to publish to the url specified in TeamCity
+    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Gradle Enterprise URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Gradle Enterprise URL
     - `buildScanPlugin.gradle.plugin-repository.url` - the URL of the repository to use when resolving the GE and CCUD plugins; required if your TeamCity agents are not able to access the Gradle Plugin Portal
     - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for _Command Line_ build steps; by default only steps using the _Gradle_ runner are enabled
 
@@ -116,14 +116,14 @@ The TeamCity configuration parameters can be set on any project and are automati
 
 1. In TeamCity, on the build configuration for which you want to integrate Gradle Enterprise, create three configuration parameters:
 
-   - `buildScanPlugin.gradle-enterprise.url` - the URL of the Gradle Enterprise instance to which to publish the Build Scan
+   - `buildScanPlugin.gradle-enterprise.url` - the URL of the Gradle Enterprise instance to which to publish build scans
    - `buildScanPlugin.gradle-enterprise.extension.version` - the version of the [Gradle Enterprise Maven extension](https://docs.gradle.com/enterprise/maven-extension/) to apply
    - `buildScanPlugin.ccud.extension.version` - the version of the [Common Custom User Data Maven extension](https://github.com/gradle/common-custom-user-data-maven-extension) to apply (optional)
 
 2. If required, provide additional configuration parameters for your environment (optional):
 
     - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Gradle Enterprise instance is using a self-signed certificate
-    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Gradle Enterprise URL over a URL configured by the project; set to _true_ to force build scans to publish to the url specified in TeamCity
+    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Gradle Enterprise URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Gradle Enterprise URL
     - `buildScanPlugin.gradle-enterprise.extension.custom.coordinates` - the coordinates of a custom extension that has a transitive dependency on the Gradle Enterprise Maven Extension
     - `buildScanPlugin.ccud.extension.custom.coordinates` - the coordinates of a custom Common Custom User Data Maven Extension or of a custom extension that has a transitive dependency on it
     - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for _Command Line_ build steps; by default only steps using the _Maven_ runner are enabled

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The TeamCity configuration parameters can be set on any project and are automati
 2. If required, provide additional configuration parameters for your environment (optional):
 
     - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Gradle Enterprise instance is using a self-signed certificate
-    - `buildScanPlugin.gradle-enterprise.override-existing-server` - override the existing server defined in the project; set to _true_ to force build scans to publish to the url specified in TeamCity
+    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Gradle Enterprise URL over a URL configured by the project; set to _true_ to force build scans to publish to the url specified in TeamCity
     - `buildScanPlugin.gradle.plugin-repository.url` - the URL of the repository to use when resolving the GE and CCUD plugins; required if your TeamCity agents are not able to access the Gradle Plugin Portal
     - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for _Command Line_ build steps; by default only steps using the _Gradle_ runner are enabled
 
@@ -123,7 +123,7 @@ The TeamCity configuration parameters can be set on any project and are automati
 2. If required, provide additional configuration parameters for your environment (optional):
 
     - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Gradle Enterprise instance is using a self-signed certificate
-    - `buildScanPlugin.gradle-enterprise.override-existing-server` - override the existing server defined in the project; set to _true_ to force build scans to publish to the url specified in TeamCity
+    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Gradle Enterprise URL over a URL configured by the project; set to _true_ to force build scans to publish to the url specified in TeamCity
     - `buildScanPlugin.gradle-enterprise.extension.custom.coordinates` - the coordinates of a custom extension that has a transitive dependency on the Gradle Enterprise Maven Extension
     - `buildScanPlugin.ccud.extension.custom.coordinates` - the coordinates of a custom Common Custom User Data Maven Extension or of a custom extension that has a transitive dependency on it
     - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for _Command Line_ build steps; by default only steps using the _Maven_ runner are enabled

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -230,8 +230,8 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
                 addSysProp(GE_EXTENSION_UPLOAD_IN_BACKGROUND_MAVEN_PROPERTY, "false", sysProps);
             } else if (Boolean.parseBoolean(getOptionalConfigParam(GE_OVERRIDE_EXISTING_SERVER_PARAM, runner))) {
-                addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
+                addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
             }
         }
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -58,7 +58,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String GRADLE_PLUGIN_REPOSITORY_CONFIG_PARAM = "buildScanPlugin.gradle.plugin-repository.url";
     private static final String GE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.url";
     private static final String GE_ALLOW_UNTRUSTED_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.allow-untrusted-server";
-    private static final String GE_OVERRIDE_EXISTING_SERVER_PARAM = "buildScanPlugin.gradle-enterprise.override-existing-server";
+    private static final String GE_ENFORCE_URL_PARAM = "buildScanPlugin.gradle-enterprise.enforce-url";
     private static final String GE_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.plugin.version";
     private static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.ccud.plugin.version";
     private static final String GE_EXTENSION_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.extension.version";
@@ -72,7 +72,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String GRADLE_PLUGIN_REPOSITORY_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL";
     private static final String GE_URL_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_URL";
     private static final String GE_ALLOW_UNTRUSTED_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER";
-    private static final String GE_OVERRIDE_EXISTING_SERVER_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_OVERRIDE_EXISTING_SERVER";
+    private static final String GE_ENFORCE_URL_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ENFORCE_URL";
     private static final String GE_PLUGIN_VERSION_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION";
     private static final String CCUD_PLUGIN_VERSION_VAR = "TEAMCITYBUILDSCANPLUGIN_CCUD_PLUGIN_VERSION";
     private static final String INIT_SCRIPT_NAME_VAR = "TEAMCITYBUILDSCANPLUGIN_INIT_SCRIPT_NAME";
@@ -155,7 +155,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
         addEnvVarIfSet(GRADLE_PLUGIN_REPOSITORY_CONFIG_PARAM, GRADLE_PLUGIN_REPOSITORY_VAR, runner);
         addEnvVarIfSet(GE_URL_CONFIG_PARAM, GE_URL_VAR, runner);
         addEnvVarIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_VAR, runner);
-        addEnvVarIfSet(GE_OVERRIDE_EXISTING_SERVER_PARAM, GE_OVERRIDE_EXISTING_SERVER_VAR, runner);
+        addEnvVarIfSet(GE_ENFORCE_URL_PARAM, GE_ENFORCE_URL_VAR, runner);
         addEnvVarIfSet(GE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_VAR, runner);
         addEnvVarIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_PLUGIN_VERSION_VAR, runner);
 
@@ -229,7 +229,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
                 addSysProp(GE_EXTENSION_UPLOAD_IN_BACKGROUND_MAVEN_PROPERTY, "false", sysProps);
-            } else if (Boolean.parseBoolean(getOptionalConfigParam(GE_OVERRIDE_EXISTING_SERVER_PARAM, runner))) {
+            } else if (Boolean.parseBoolean(getOptionalConfigParam(GE_ENFORCE_URL_PARAM, runner))) {
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
             }

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -223,15 +223,16 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
         String geExtensionVersion = getOptionalConfigParam(GE_EXTENSION_VERSION_CONFIG_PARAM, runner);
         if (geExtensionVersion != null) {
             MavenCoordinates customGeExtensionCoords = parseCoordinates(getOptionalConfigParam(CUSTOM_GE_EXTENSION_COORDINATES_CONFIG_PARAM, runner));
+            String geUrl = getOptionalConfigParam(GE_URL_CONFIG_PARAM, runner);
             if (!extensions.hasExtension(GE_EXTENSION_MAVEN_COORDINATES) && !extensions.hasExtension(customGeExtensionCoords)) {
                 extensionApplicationListener.geExtensionApplied(geExtensionVersion);
                 extensionJars.add(getExtensionJar(GRADLE_ENTERPRISE_EXT_MAVEN, runner));
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
                 addSysProp(GE_EXTENSION_UPLOAD_IN_BACKGROUND_MAVEN_PROPERTY, "false", sysProps);
-            } else if (Boolean.parseBoolean(getOptionalConfigParam(GE_ENFORCE_URL_PARAM, runner))) {
-                addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
+            } else if (geUrl != null && Boolean.parseBoolean(getOptionalConfigParam(GE_ENFORCE_URL_PARAM, runner))) {
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
+                addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
             }
         }
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -229,6 +229,9 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
                 addSysProp(GE_EXTENSION_UPLOAD_IN_BACKGROUND_MAVEN_PROPERTY, "false", sysProps);
+            } else if (Boolean.parseBoolean(getOptionalConfigParam(GE_OVERRIDE_EXISTING_SERVER_PARAM, runner))) {
+                addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
+                addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
             }
         }
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -58,6 +58,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String GRADLE_PLUGIN_REPOSITORY_CONFIG_PARAM = "buildScanPlugin.gradle.plugin-repository.url";
     private static final String GE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.url";
     private static final String GE_ALLOW_UNTRUSTED_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.allow-untrusted-server";
+    private static final String GE_OVERRIDE_EXISTING_SERVER_PARAM = "buildScanPlugin.gradle-enterprise.override-existing-server";
     private static final String GE_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.plugin.version";
     private static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.ccud.plugin.version";
     private static final String GE_EXTENSION_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.extension.version";
@@ -71,6 +72,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String GRADLE_PLUGIN_REPOSITORY_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL";
     private static final String GE_URL_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_URL";
     private static final String GE_ALLOW_UNTRUSTED_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER";
+    private static final String GE_OVERRIDE_EXISTING_SERVER_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_OVERRIDE_EXISTING_SERVER";
     private static final String GE_PLUGIN_VERSION_VAR = "TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION";
     private static final String CCUD_PLUGIN_VERSION_VAR = "TEAMCITYBUILDSCANPLUGIN_CCUD_PLUGIN_VERSION";
     private static final String INIT_SCRIPT_NAME_VAR = "TEAMCITYBUILDSCANPLUGIN_INIT_SCRIPT_NAME";
@@ -153,6 +155,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
         addEnvVarIfSet(GRADLE_PLUGIN_REPOSITORY_CONFIG_PARAM, GRADLE_PLUGIN_REPOSITORY_VAR, runner);
         addEnvVarIfSet(GE_URL_CONFIG_PARAM, GE_URL_VAR, runner);
         addEnvVarIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_VAR, runner);
+        addEnvVarIfSet(GE_OVERRIDE_EXISTING_SERVER_PARAM, GE_OVERRIDE_EXISTING_SERVER_VAR, runner);
         addEnvVarIfSet(GE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_VAR, runner);
         addEnvVarIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_PLUGIN_VERSION_VAR, runner);
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -58,7 +58,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String GRADLE_PLUGIN_REPOSITORY_CONFIG_PARAM = "buildScanPlugin.gradle.plugin-repository.url";
     private static final String GE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.url";
     private static final String GE_ALLOW_UNTRUSTED_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.allow-untrusted-server";
-    private static final String GE_ENFORCE_URL_PARAM = "buildScanPlugin.gradle-enterprise.enforce-url";
+    private static final String GE_ENFORCE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.enforce-url";
     private static final String GE_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.plugin.version";
     private static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.ccud.plugin.version";
     private static final String GE_EXTENSION_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.extension.version";
@@ -155,7 +155,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
         addEnvVarIfSet(GRADLE_PLUGIN_REPOSITORY_CONFIG_PARAM, GRADLE_PLUGIN_REPOSITORY_VAR, runner);
         addEnvVarIfSet(GE_URL_CONFIG_PARAM, GE_URL_VAR, runner);
         addEnvVarIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_VAR, runner);
-        addEnvVarIfSet(GE_ENFORCE_URL_PARAM, GE_ENFORCE_URL_VAR, runner);
+        addEnvVarIfSet(GE_ENFORCE_URL_CONFIG_PARAM, GE_ENFORCE_URL_VAR, runner);
         addEnvVarIfSet(GE_PLUGIN_VERSION_CONFIG_PARAM, GE_PLUGIN_VERSION_VAR, runner);
         addEnvVarIfSet(CCUD_PLUGIN_VERSION_CONFIG_PARAM, CCUD_PLUGIN_VERSION_VAR, runner);
 
@@ -230,7 +230,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
                 addSysProp(GE_EXTENSION_UPLOAD_IN_BACKGROUND_MAVEN_PROPERTY, "false", sysProps);
-            } else if (geUrl != null && Boolean.parseBoolean(getOptionalConfigParam(GE_ENFORCE_URL_PARAM, runner))) {
+            } else if (geUrl != null && Boolean.parseBoolean(getOptionalConfigParam(GE_ENFORCE_URL_CONFIG_PARAM, runner))) {
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
             }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -107,6 +107,7 @@ def buildScanPublishedAction = { def buildScan ->
 
 // register buildScanPublished listener and optionally apply the GE / Build Scan plugin
 if (GradleVersion.current() < GradleVersion.version('6.0')) {
+    //noinspection GroovyAssignabilityCheck
     rootProject {
         buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
             def resolutionResult = incoming.resolutionResult
@@ -115,6 +116,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 def scanPluginComponent = resolutionResult.allComponents.find {
                     it.moduleVersion.with { group == "com.gradle" && (name == "build-scan-plugin" || name == "gradle-enterprise-gradle-plugin") }
                 }
+
                 if (!scanPluginComponent) {
                     logger.quiet("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
@@ -129,7 +131,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (geUrl && geOverrideServerUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, overrideServerUrl: $geOverrideServerUrl")
+                            logger.quiet("Enforcing Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
                         }
@@ -141,6 +143,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 def ccudPluginComponent = resolutionResult.allComponents.find {
                     it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
                 }
+
                 if (!ccudPluginComponent) {
                     logger.quiet("Applying $CCUD_PLUGIN_CLASS via init script")
                     pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
@@ -170,7 +173,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
             if (geUrl && geOverrideServerUrl) {
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
-                    logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, overrideServerUrl: $geOverrideServerUrl")
+                    logger.quiet("Enforcing Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                 }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -78,6 +78,7 @@ if (requestedInitScriptName != initScriptName) {
 
 def geUrl = getInputParam('teamCityBuildScanPlugin.gradle-enterprise.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('teamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server'))
+def geOverrideServerUrl = Boolean.parseBoolean(getInputParam('teamCityBuildScanPlugin.gradle-enterprise.override-existing-server'))
 def gePluginVersion = getInputParam('teamCityBuildScanPlugin.gradle-enterprise.plugin.version')
 def ccudPluginVersion = getInputParam('teamCityBuildScanPlugin.ccud.plugin.version')
 
@@ -124,6 +125,16 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = false  // uploadInBackground not available for build-scan-plugin 1.16
                     buildScan.value 'CI auto injection', 'TeamCity'
                 }
+
+                if (geUrl && geOverrideServerUrl) {
+                    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                        afterEvaluate {
+                            logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, overrideServerUrl: $geOverrideServerUrl")
+                            buildScan.server = geUrl
+                            buildScan.allowUntrustedServer = geAllowUntrustedServer
+                        }
+                    }
+                }
             }
 
             if (ccudPluginVersion && atLeastGradle4) {
@@ -154,6 +165,14 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = false
                     ext.buildScan.value 'CI auto injection', 'TeamCity'
+                }
+            }
+
+            if (geUrl && geOverrideServerUrl) {
+                extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
+                    logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, overrideServerUrl: $geOverrideServerUrl")
+                    ext.server = geUrl
+                    ext.allowUntrustedServer = geAllowUntrustedServer
                 }
             }
         }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -78,7 +78,7 @@ if (requestedInitScriptName != initScriptName) {
 
 def geUrl = getInputParam('teamCityBuildScanPlugin.gradle-enterprise.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('teamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server'))
-def geOverrideServerUrl = Boolean.parseBoolean(getInputParam('teamCityBuildScanPlugin.gradle-enterprise.override-existing-server'))
+def geEnforceUrl = Boolean.parseBoolean(getInputParam('teamCityBuildScanPlugin.gradle-enterprise.enforce-url'))
 def gePluginVersion = getInputParam('teamCityBuildScanPlugin.gradle-enterprise.plugin.version')
 def ccudPluginVersion = getInputParam('teamCityBuildScanPlugin.ccud.plugin.version')
 
@@ -128,7 +128,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScan.value 'CI auto injection', 'TeamCity'
                 }
 
-                if (geUrl && geOverrideServerUrl) {
+                if (geUrl && geEnforceUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
                             logger.quiet("Enforcing Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
@@ -171,7 +171,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 }
             }
 
-            if (geUrl && geOverrideServerUrl) {
+            if (geUrl && geEnforceUrl) {
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
                     logger.quiet("Enforcing Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                     ext.server = geUrl

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TcPluginConfig.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TcPluginConfig.groovy
@@ -5,6 +5,7 @@ class TcPluginConfig {
     URI gradlePluginRepositoryUrl
     URI geUrl
     boolean geAllowUntrustedServer
+    boolean geOverrideServerUrl
     String gePluginVersion
     String ccudPluginVersion
     String geExtensionVersion
@@ -24,6 +25,9 @@ class TcPluginConfig {
         }
         if (geAllowUntrustedServer) {
             configProps.put 'buildScanPlugin.gradle-enterprise.allow-untrusted-server', 'true'
+        }
+        if (geOverrideServerUrl) {
+            configProps.put 'buildScanPlugin.gradle-enterprise.override-existing-server', 'true'
         }
         if (gePluginVersion) {
             configProps.put 'buildScanPlugin.gradle-enterprise.plugin.version', gePluginVersion

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TcPluginConfig.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/TcPluginConfig.groovy
@@ -5,7 +5,7 @@ class TcPluginConfig {
     URI gradlePluginRepositoryUrl
     URI geUrl
     boolean geAllowUntrustedServer
-    boolean geOverrideServerUrl
+    boolean geEnforceUrl
     String gePluginVersion
     String ccudPluginVersion
     String geExtensionVersion
@@ -26,8 +26,8 @@ class TcPluginConfig {
         if (geAllowUntrustedServer) {
             configProps.put 'buildScanPlugin.gradle-enterprise.allow-untrusted-server', 'true'
         }
-        if (geOverrideServerUrl) {
-            configProps.put 'buildScanPlugin.gradle-enterprise.override-existing-server', 'true'
+        if (geEnforceUrl) {
+            configProps.put 'buildScanPlugin.gradle-enterprise.enforce-url', 'true'
         }
         if (gePluginVersion) {
             configProps.put 'buildScanPlugin.gradle-enterprise.plugin.version', gePluginVersion

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
@@ -136,17 +136,17 @@ class BaseInitScriptTest extends Specification {
         buildFile << ''
     }
 
-    def declareGePluginApplication(GradleVersion gradleVersion) {
-        settingsFile << maybeAddPluginsToSettings(gradleVersion)
-        buildFile << maybeAddPluginsToRootProject(gradleVersion)
+    def declareGePluginApplication(GradleVersion gradleVersion, URI geUrl = mockScansServer.address) {
+        settingsFile << maybeAddPluginsToSettings(gradleVersion, geUrl)
+        buildFile << maybeAddPluginsToRootProject(gradleVersion, geUrl)
     }
 
-    def declareGePluginAndCcudPluginApplication(GradleVersion gradleVersion) {
-        settingsFile << maybeAddPluginsToSettings(gradleVersion, '1.10')
-        buildFile << maybeAddPluginsToRootProject(gradleVersion, '1.10')
+    def declareGePluginAndCcudPluginApplication(GradleVersion gradleVersion, URI geUrl = mockScansServer.address) {
+        settingsFile << maybeAddPluginsToSettings(gradleVersion, geUrl, '1.10')
+        buildFile << maybeAddPluginsToRootProject(gradleVersion, geUrl, '1.10')
     }
 
-    String maybeAddPluginsToSettings(GradleVersion gradleVersion, String ccudPluginVersion = null) {
+    String maybeAddPluginsToSettings(GradleVersion gradleVersion, URI geUrl, String ccudPluginVersion = null) {
         if (gradleVersion < GradleVersion.version('5.0')) {
             '' // applied in build.gradle
         } else if (gradleVersion < GradleVersion.version('6.0')) {
@@ -158,7 +158,7 @@ class BaseInitScriptTest extends Specification {
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
               gradleEnterprise {
-                server = '$mockScansServer.address'
+                server = '$geUrl'
                 buildScan {
                   publishAlways()
                 }
@@ -167,7 +167,7 @@ class BaseInitScriptTest extends Specification {
         }
     }
 
-    String maybeAddPluginsToRootProject(GradleVersion gradleVersion, String ccudPluginVersion = null) {
+    String maybeAddPluginsToRootProject(GradleVersion gradleVersion, URI geUrl, String ccudPluginVersion = null) {
         if (gradleVersion < GradleVersion.version('5.0')) {
             """
               plugins {
@@ -175,7 +175,7 @@ class BaseInitScriptTest extends Specification {
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
               buildScan {
-                server = '$mockScansServer.address'
+                server = '$geUrl'
                 publishAlways()
               }
             """
@@ -186,7 +186,7 @@ class BaseInitScriptTest extends Specification {
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
               gradleEnterprise {
-                server = '$mockScansServer.address'
+                server = '$geUrl'
                 buildScan {
                   publishAlways()
                 }
@@ -270,12 +270,13 @@ class BaseInitScriptTest extends Specification {
     // for TestKit versions that don't support environment variables, map those vars to system properties
     private static List<String> mapEnvVarsToSystemProps(Map<String, String> envVars) {
         def mapping = [
-            TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_URL                   : "teamCityBuildScanPlugin.gradle-enterprise.url",
-            TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER: "teamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server",
-            TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION        : "teamCityBuildScanPlugin.gradle-enterprise.plugin.version",
-            TEAMCITYBUILDSCANPLUGIN_CCUD_PLUGIN_VERSION                     : "teamCityBuildScanPlugin.ccud.plugin.version",
-            TEAMCITYBUILDSCANPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL            : "teamCityBuildScanPlugin.gradle.plugin-repository.url",
-            TEAMCITYBUILDSCANPLUGIN_INIT_SCRIPT_NAME                        : "teamCityBuildScanPlugin.init-script.name"
+            TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_URL                     : "teamCityBuildScanPlugin.gradle-enterprise.url",
+            TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER  : "teamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server",
+            TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_OVERRIDE_EXISTING_SERVER: "teamCityBuildScanPlugin.gradle-enterprise.override-existing-server",
+            TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION          : "teamCityBuildScanPlugin.gradle-enterprise.plugin.version",
+            TEAMCITYBUILDSCANPLUGIN_CCUD_PLUGIN_VERSION                       : "teamCityBuildScanPlugin.ccud.plugin.version",
+            TEAMCITYBUILDSCANPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL              : "teamCityBuildScanPlugin.gradle.plugin-repository.url",
+            TEAMCITYBUILDSCANPLUGIN_INIT_SCRIPT_NAME                          : "teamCityBuildScanPlugin.init-script.name"
         ]
 
         return envVars.entrySet().stream().map(e -> {

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
@@ -272,7 +272,7 @@ class BaseInitScriptTest extends Specification {
         def mapping = [
             TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_URL                     : "teamCityBuildScanPlugin.gradle-enterprise.url",
             TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER  : "teamCityBuildScanPlugin.gradle-enterprise.allow-untrusted-server",
-            TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_OVERRIDE_EXISTING_SERVER: "teamCityBuildScanPlugin.gradle-enterprise.override-existing-server",
+            TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_ENFORCE_URL             : "teamCityBuildScanPlugin.gradle-enterprise.enforce-url",
             TEAMCITYBUILDSCANPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION          : "teamCityBuildScanPlugin.gradle-enterprise.plugin.version",
             TEAMCITYBUILDSCANPLUGIN_CCUD_PLUGIN_VERSION                       : "teamCityBuildScanPlugin.ccud.plugin.version",
             TEAMCITYBUILDSCANPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL              : "teamCityBuildScanPlugin.gradle.plugin-repository.url",

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
@@ -178,6 +178,31 @@ class GEPluginApplicationInitScriptTest extends BaseInitScriptTest {
         jdkCompatibleGradleVersion << GRADLE_VERSIONS_2_AND_HIGHER
     }
 
+    def "overrides GE URL and allowUntrustedServer in project if override parameter is enabled (#jdkCompatibleGradleVersion)"() {
+        assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
+
+        given:
+        declareGePluginApplication(jdkCompatibleGradleVersion.gradleVersion, URI.create('https://ge-server.invalid'))
+
+        when:
+        def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, geAllowUntrustedServer: true, gePluginVersion: GE_PLUGIN_VERSION, geOverrideServerUrl: true)
+        def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
+
+        then:
+        outputMissesGePluginApplicationViaInitScript(result)
+        outputMissesCcudPluginApplicationViaInitScript(result)
+
+        and:
+        outputContainsGeConnectionInfo(result, mockScansServer.address.toString(), true)
+
+        and:
+        outputContainsTeamCityServiceMessageBuildStarted(result)
+        outputContainsTeamCityServiceMessageBuildScanUrl(result)
+
+        where:
+        jdkCompatibleGradleVersion << GRADLE_VERSIONS_2_AND_HIGHER
+    }
+
     def "can configure alternative repository for plugins when GE plugin is applied by the init script (#jdkCompatibleGradleVersion)"() {
         assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
 

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
@@ -193,7 +193,7 @@ class GEPluginApplicationInitScriptTest extends BaseInitScriptTest {
         outputMissesCcudPluginApplicationViaInitScript(result)
 
         and:
-        outputContainsGeConnectionInfo(result, mockScansServer.address.toString(), true)
+        outputEnforcesGeUrl(result, mockScansServer.address.toString(), true)
 
         and:
         outputContainsTeamCityServiceMessageBuildStarted(result)
@@ -367,6 +367,12 @@ class GEPluginApplicationInitScriptTest extends BaseInitScriptTest {
         def repositoryInfo = "Gradle Enterprise plugins resolution: ${gradlePluginRepositoryUrl}"
         assert result.output.contains(repositoryInfo)
         assert 1 == result.output.count(repositoryInfo)
+    }
+
+    void outputEnforcesGeUrl(BuildResult result, String geUrl, boolean geAllowUntrustedServer) {
+        def enforceUrl = "Enforcing Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer"
+        assert result.output.contains(enforceUrl)
+        assert 1 == result.output.count(enforceUrl)
     }
 
 }

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
@@ -178,14 +178,14 @@ class GEPluginApplicationInitScriptTest extends BaseInitScriptTest {
         jdkCompatibleGradleVersion << GRADLE_VERSIONS_2_AND_HIGHER
     }
 
-    def "overrides GE URL and allowUntrustedServer in project if override parameter is enabled (#jdkCompatibleGradleVersion)"() {
+    def "enforces GE URL and allowUntrustedServer in project if enforce url parameter is enabled (#jdkCompatibleGradleVersion)"() {
         assumeTrue jdkCompatibleGradleVersion.isJvmVersionCompatible()
 
         given:
         declareGePluginApplication(jdkCompatibleGradleVersion.gradleVersion, URI.create('https://ge-server.invalid'))
 
         when:
-        def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, geAllowUntrustedServer: true, gePluginVersion: GE_PLUGIN_VERSION, geOverrideServerUrl: true)
+        def gePluginConfig = new TcPluginConfig(geUrl: mockScansServer.address, geAllowUntrustedServer: true, gePluginVersion: GE_PLUGIN_VERSION, geEnforceUrl: true)
         def result = run(jdkCompatibleGradleVersion.gradleVersion, gePluginConfig)
 
         then:

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/UrlConfigurationExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/UrlConfigurationExtensionApplicationTest.groovy
@@ -71,7 +71,7 @@ class UrlConfigurationExtensionApplicationTest extends BaseExtensionApplicationT
         jdkCompatibleMavenVersion << SUPPORTED_MAVEN_VERSIONS
     }
 
-    def "overrides GE URL and allowUntrustedServer in project if override parameter is enabled (#jdkCompatibleMavenVersion)"() {
+    def "enforces GE URL and allowUntrustedServer in project if enforce url parameter is enabled (#jdkCompatibleMavenVersion)"() {
         assumeTrue jdkCompatibleMavenVersion.isJvmVersionCompatible()
         assumeTrue GE_URL != null
 
@@ -85,7 +85,7 @@ class UrlConfigurationExtensionApplicationTest extends BaseExtensionApplicationT
         def gePluginConfig = new TcPluginConfig(
                 geUrl: GE_URL,
                 geAllowUntrustedServer: true,
-                geOverrideServerUrl: true,
+                geEnforceUrl: true,
                 geExtensionVersion: GE_EXTENSION_VERSION,
         )
 

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/UrlConfigurationExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/UrlConfigurationExtensionApplicationTest.groovy
@@ -103,4 +103,5 @@ class UrlConfigurationExtensionApplicationTest extends BaseExtensionApplicationT
         where:
         jdkCompatibleMavenVersion << SUPPORTED_MAVEN_VERSIONS
     }
+
 }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- TBD
+- Allows to enforce the Gradle Enterprise URL over what might be configured in the project's build

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -8,8 +8,8 @@ public final class GradleEnterpriseConnectionConstants {
 
     public static final String GRADLE_PLUGIN_REPOSITORY_URL = "gradlePluginRepositoryUrl";
     public static final String GRADLE_ENTERPRISE_URL = "gradleEnterpriseUrl";
-    public static final String OVERRIDE_EXISTING_SERVER = "overrideExistingServer";
     public static final String ALLOW_UNTRUSTED_SERVER = "allowUntrustedServer";
+    public static final String OVERRIDE_EXISTING_SERVER = "overrideExistingServer";
     public static final String GE_PLUGIN_VERSION = "gradleEnterprisePluginVersion";
     public static final String CCUD_PLUGIN_VERSION = "commonCustomUserDataPluginVersion";
     public static final String GE_EXTENSION_VERSION = "gradleEnterpriseExtensionVersion";
@@ -47,12 +47,12 @@ public final class GradleEnterpriseConnectionConstants {
         return GRADLE_ENTERPRISE_URL;
     }
 
-    public String getOverrideExistingServer() {
-        return OVERRIDE_EXISTING_SERVER;
-    }
-
     public String getAllowUntrustedServer() {
         return ALLOW_UNTRUSTED_SERVER;
+    }
+
+    public String getOverrideExistingServer() {
+        return OVERRIDE_EXISTING_SERVER;
     }
 
     public String getGradleEnterprisePluginVersion() {

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -9,7 +9,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String GRADLE_PLUGIN_REPOSITORY_URL = "gradlePluginRepositoryUrl";
     public static final String GRADLE_ENTERPRISE_URL = "gradleEnterpriseUrl";
     public static final String ALLOW_UNTRUSTED_SERVER = "allowUntrustedServer";
-    public static final String ENFORCE_URL = "enforceUrl";
+    public static final String ENFORCE_GRADLE_ENTERPRISE_URL = "enforceUrl";
     public static final String GE_PLUGIN_VERSION = "gradleEnterprisePluginVersion";
     public static final String CCUD_PLUGIN_VERSION = "commonCustomUserDataPluginVersion";
     public static final String GE_EXTENSION_VERSION = "gradleEnterpriseExtensionVersion";
@@ -25,7 +25,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM = "buildScanPlugin.gradle.plugin-repository.url";
     public static final String GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.url";
     public static final String ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.allow-untrusted-server";
-    public static final String ENFORCE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.enforce-url";
+    public static final String ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.enforce-url";
     public static final String GE_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.plugin.version";
     public static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.ccud.plugin.version";
     public static final String GE_EXTENSION_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.extension.version";
@@ -52,7 +52,7 @@ public final class GradleEnterpriseConnectionConstants {
     }
 
     public String getEnforceUrl() {
-        return ENFORCE_URL;
+        return ENFORCE_GRADLE_ENTERPRISE_URL;
     }
 
     public String getGradleEnterprisePluginVersion() {

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -9,7 +9,6 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String GRADLE_PLUGIN_REPOSITORY_URL = "gradlePluginRepositoryUrl";
     public static final String GRADLE_ENTERPRISE_URL = "gradleEnterpriseUrl";
     public static final String ALLOW_UNTRUSTED_SERVER = "allowUntrustedServer";
-    public static final String ENFORCE_GRADLE_ENTERPRISE_URL = "enforceUrl";
     public static final String GE_PLUGIN_VERSION = "gradleEnterprisePluginVersion";
     public static final String CCUD_PLUGIN_VERSION = "commonCustomUserDataPluginVersion";
     public static final String GE_EXTENSION_VERSION = "gradleEnterpriseExtensionVersion";
@@ -18,6 +17,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String CUSTOM_CCUD_EXTENSION_COORDINATES = "customCommonCustomUserDataExtensionCoordinates";
     public static final String INSTRUMENT_COMMAND_LINE_BUILD_STEP = "instrumentCommandLineBuildStep";
     public static final String GRADLE_ENTERPRISE_ACCESS_KEY = "gradleEnterpriseAccessKey";
+    public static final String ENFORCE_GRADLE_ENTERPRISE_URL = "enforceUrl";
 
     // Constants defined by the BuildScanServiceMessageInjector
     // This connection sets these values as build parameters so that they can be picked up by the BuildScanServiceMessageInjector
@@ -25,7 +25,6 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM = "buildScanPlugin.gradle.plugin-repository.url";
     public static final String GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.url";
     public static final String ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.allow-untrusted-server";
-    public static final String ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.enforce-url";
     public static final String GE_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.plugin.version";
     public static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.ccud.plugin.version";
     public static final String GE_EXTENSION_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.extension.version";
@@ -34,6 +33,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM = "buildScanPlugin.ccud.extension.custom.coordinates";
     public static final String INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM = "buildScanPlugin.command-line-build-step.enabled";
     public static final String GRADLE_ENTERPRISE_ACCESS_KEY_ENV_VAR = "env.GRADLE_ENTERPRISE_ACCESS_KEY";
+    public static final String ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.enforce-url";
 
     public static final String GRADLE_ENTERPRISE_CONNECTION_PROVIDER = "gradle-enterprise-connection-provider";
 
@@ -49,10 +49,6 @@ public final class GradleEnterpriseConnectionConstants {
 
     public String getAllowUntrustedServer() {
         return ALLOW_UNTRUSTED_SERVER;
-    }
-
-    public String getEnforceUrl() {
-        return ENFORCE_GRADLE_ENTERPRISE_URL;
     }
 
     public String getGradleEnterprisePluginVersion() {
@@ -85,6 +81,10 @@ public final class GradleEnterpriseConnectionConstants {
 
     public String getGradleEnterpriseAccessKey() {
         return GRADLE_ENTERPRISE_ACCESS_KEY;
+    }
+
+    public String getEnforceUrl() {
+        return ENFORCE_GRADLE_ENTERPRISE_URL;
     }
 
 }

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -9,7 +9,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String GRADLE_PLUGIN_REPOSITORY_URL = "gradlePluginRepositoryUrl";
     public static final String GRADLE_ENTERPRISE_URL = "gradleEnterpriseUrl";
     public static final String ALLOW_UNTRUSTED_SERVER = "allowUntrustedServer";
-    public static final String OVERRIDE_EXISTING_SERVER = "overrideExistingServer";
+    public static final String ENFORCE_URL = "enforceUrl";
     public static final String GE_PLUGIN_VERSION = "gradleEnterprisePluginVersion";
     public static final String CCUD_PLUGIN_VERSION = "commonCustomUserDataPluginVersion";
     public static final String GE_EXTENSION_VERSION = "gradleEnterpriseExtensionVersion";
@@ -25,7 +25,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM = "buildScanPlugin.gradle.plugin-repository.url";
     public static final String GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.url";
     public static final String ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.allow-untrusted-server";
-    public static final String OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.override-existing-server";
+    public static final String ENFORCE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.enforce-url";
     public static final String GE_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.plugin.version";
     public static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.ccud.plugin.version";
     public static final String GE_EXTENSION_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.extension.version";
@@ -51,8 +51,8 @@ public final class GradleEnterpriseConnectionConstants {
         return ALLOW_UNTRUSTED_SERVER;
     }
 
-    public String getOverrideExistingServer() {
-        return OVERRIDE_EXISTING_SERVER;
+    public String getEnforceUrl() {
+        return ENFORCE_URL;
     }
 
     public String getGradleEnterprisePluginVersion() {

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -83,7 +83,7 @@ public final class GradleEnterpriseConnectionConstants {
         return GRADLE_ENTERPRISE_ACCESS_KEY;
     }
 
-    public String getEnforceUrl() {
+    public String getEnforceGradleEnterpriseUrl() {
         return ENFORCE_GRADLE_ENTERPRISE_URL;
     }
 

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -17,7 +17,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String CUSTOM_CCUD_EXTENSION_COORDINATES = "customCommonCustomUserDataExtensionCoordinates";
     public static final String INSTRUMENT_COMMAND_LINE_BUILD_STEP = "instrumentCommandLineBuildStep";
     public static final String GRADLE_ENTERPRISE_ACCESS_KEY = "gradleEnterpriseAccessKey";
-    public static final String ENFORCE_GRADLE_ENTERPRISE_URL = "enforceUrl";
+    public static final String ENFORCE_GRADLE_ENTERPRISE_URL = "enforceGradleEnterpriseUrl";
 
     // Constants defined by the BuildScanServiceMessageInjector
     // This connection sets these values as build parameters so that they can be picked up by the BuildScanServiceMessageInjector

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -8,6 +8,7 @@ public final class GradleEnterpriseConnectionConstants {
 
     public static final String GRADLE_PLUGIN_REPOSITORY_URL = "gradlePluginRepositoryUrl";
     public static final String GRADLE_ENTERPRISE_URL = "gradleEnterpriseUrl";
+    public static final String OVERRIDE_EXISTING_SERVER = "overrideExistingServer";
     public static final String ALLOW_UNTRUSTED_SERVER = "allowUntrustedServer";
     public static final String GE_PLUGIN_VERSION = "gradleEnterprisePluginVersion";
     public static final String CCUD_PLUGIN_VERSION = "commonCustomUserDataPluginVersion";
@@ -24,6 +25,7 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM = "buildScanPlugin.gradle.plugin-repository.url";
     public static final String GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.url";
     public static final String ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.allow-untrusted-server";
+    public static final String OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.override-existing-server";
     public static final String GE_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.plugin.version";
     public static final String CCUD_PLUGIN_VERSION_CONFIG_PARAM = "buildScanPlugin.ccud.plugin.version";
     public static final String GE_EXTENSION_VERSION_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.extension.version";
@@ -43,6 +45,10 @@ public final class GradleEnterpriseConnectionConstants {
 
     public String getGradleEnterpriseUrl() {
         return GRADLE_ENTERPRISE_URL;
+    }
+
+    public String getOverrideExistingServer() {
+        return OVERRIDE_EXISTING_SERVER;
     }
 
     public String getAllowUntrustedServer() {

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -78,14 +78,14 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
             description += String.format("* Allow Untrusted Server: %s\n", allowUntrustedServer);
         }
 
-        String enforceGeUrl = params.get(ENFORCE_GRADLE_ENTERPRISE_URL);
-        if (enforceGeUrl != null) {
-            description += String.format("* Enforce Gradle Enterprise Server URL: %s\n", enforceGeUrl);
-        }
-
         String geAccessKey = params.get(GRADLE_ENTERPRISE_ACCESS_KEY);
         if (geAccessKey != null) {
             description += String.format("* Gradle Enterprise Access Key: %s\n", "******");
+        }
+
+        String enforceGeUrl = params.get(ENFORCE_GRADLE_ENTERPRISE_URL);
+        if (enforceGeUrl != null) {
+            description += String.format("* Enforce Gradle Enterprise Server URL: %s\n", enforceGeUrl);
         }
 
         description += "\nGradle Settings:\n";
@@ -167,7 +167,7 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
         return defaultProperties;
     }
 
-    @Nullable
+    @NotNull
     @Override
     public PropertiesProcessor getPropertiesProcessor() {
         return properties -> {
@@ -179,4 +179,5 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
             return errors;
         };
     }
+
 }

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -11,13 +11,18 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ALLOW_UNTRUSTED_SERVER;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.CCUD_EXTENSION_VERSION;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.CCUD_PLUGIN_VERSION;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.CUSTOM_CCUD_EXTENSION_COORDINATES;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.CUSTOM_GE_EXTENSION_COORDINATES;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GE_EXTENSION_VERSION;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GE_PLUGIN_VERSION;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_ENTERPRISE_ACCESS_KEY;
@@ -25,7 +30,6 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_ENTERPRISE_URL;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP;
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER;
 
 public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
 
@@ -74,7 +78,7 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
             description += String.format("* Allow Untrusted Server: %s\n", allowUntrustedServer);
         }
 
-        String overrideUrl = params.get(OVERRIDE_EXISTING_SERVER);
+        String overrideUrl = params.get(ENFORCE_URL);
         if (overrideUrl != null) {
             description += String.format("* Override Pre-Existing Gradle Enterprise Server: %s\n", overrideUrl);
         }

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -80,7 +80,7 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
 
         String overrideUrl = params.get(ENFORCE_URL);
         if (overrideUrl != null) {
-            description += String.format("* Override Pre-Existing Gradle Enterprise Server: %s\n", overrideUrl);
+            description += String.format("* Enforce Server URL: %s\n", overrideUrl);
         }
 
         String geAccessKey = params.get(GRADLE_ENTERPRISE_ACCESS_KEY);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -78,9 +78,9 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
             description += String.format("* Allow Untrusted Server: %s\n", allowUntrustedServer);
         }
 
-        String overrideUrl = params.get(ENFORCE_URL);
-        if (overrideUrl != null) {
-            description += String.format("* Enforce Server URL: %s\n", overrideUrl);
+        String enforceUrl = params.get(ENFORCE_URL);
+        if (enforceUrl != null) {
+            description += String.format("* Enforce Server URL: %s\n", enforceUrl);
         }
 
         String geAccessKey = params.get(GRADLE_ENTERPRISE_ACCESS_KEY);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -11,11 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ALLOW_UNTRUSTED_SERVER;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.CCUD_EXTENSION_VERSION;
@@ -73,14 +69,14 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
             description += String.format("* Gradle Enterprise Server URL: %s\n", geUrl);
         }
 
-        String overrideUrl = params.get(OVERRIDE_EXISTING_SERVER);
-        if (overrideUrl != null) {
-            description += String.format("* Override Pre-Existing Gradle Enterprise Server: %s\n", overrideUrl);
-        }
-
         String allowUntrustedServer = params.get(ALLOW_UNTRUSTED_SERVER);
         if (allowUntrustedServer != null) {
             description += String.format("* Allow Untrusted Server: %s\n", allowUntrustedServer);
+        }
+
+        String overrideUrl = params.get(OVERRIDE_EXISTING_SERVER);
+        if (overrideUrl != null) {
+            description += String.format("* Override Pre-Existing Gradle Enterprise Server: %s\n", overrideUrl);
         }
 
         String geAccessKey = params.get(GRADLE_ENTERPRISE_ACCESS_KEY);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -29,6 +29,7 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_ENTERPRISE_URL;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER;
 
 public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
 
@@ -70,6 +71,11 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
         String geUrl = params.get(GRADLE_ENTERPRISE_URL);
         if (geUrl != null) {
             description += String.format("* Gradle Enterprise Server URL: %s\n", geUrl);
+        }
+
+        String overrideUrl = params.get(OVERRIDE_EXISTING_SERVER);
+        if (overrideUrl != null) {
+            description += String.format("* Override Pre-Existing Gradle Enterprise Server: %s\n", overrideUrl);
         }
 
         String allowUntrustedServer = params.get(ALLOW_UNTRUSTED_SERVER);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -22,7 +22,7 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.CCUD_PLUGIN_VERSION;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.CUSTOM_CCUD_EXTENSION_COORDINATES;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.CUSTOM_GE_EXTENSION_COORDINATES;
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_GRADLE_ENTERPRISE_URL;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GE_EXTENSION_VERSION;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GE_PLUGIN_VERSION;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_ENTERPRISE_ACCESS_KEY;
@@ -78,7 +78,7 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
             description += String.format("* Allow Untrusted Server: %s\n", allowUntrustedServer);
         }
 
-        String enforceUrl = params.get(ENFORCE_URL);
+        String enforceUrl = params.get(ENFORCE_GRADLE_ENTERPRISE_URL);
         if (enforceUrl != null) {
             description += String.format("* Enforce Server URL: %s\n", enforceUrl);
         }

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -78,9 +78,9 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
             description += String.format("* Allow Untrusted Server: %s\n", allowUntrustedServer);
         }
 
-        String enforceUrl = params.get(ENFORCE_GRADLE_ENTERPRISE_URL);
-        if (enforceUrl != null) {
-            description += String.format("* Enforce Server URL: %s\n", enforceUrl);
+        String enforceGeUrl = params.get(ENFORCE_GRADLE_ENTERPRISE_URL);
+        if (enforceGeUrl != null) {
+            description += String.format("* Enforce Gradle Enterprise Server URL: %s\n", enforceGeUrl);
         }
 
         String geAccessKey = params.get(GRADLE_ENTERPRISE_ACCESS_KEY);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
@@ -37,6 +37,8 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM;
 
 /**
  * This implementation of {@link BuildParametersProvider} injects configuration parameters and environment variables
@@ -57,6 +59,7 @@ public final class GradleEnterpriseParametersProvider implements BuildParameters
             Map<String, String> connectionParams = connections.get(i);
             setParameter(GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM, connectionParams.get(GRADLE_PLUGIN_REPOSITORY_URL), params);
             setParameter(GRADLE_ENTERPRISE_URL_CONFIG_PARAM, connectionParams.get(GRADLE_ENTERPRISE_URL), params);
+            setParameter(OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM, connectionParams.get(OVERRIDE_EXISTING_SERVER), params);
             setParameter(ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM, connectionParams.get(ALLOW_UNTRUSTED_SERVER), params);
             setParameter(GE_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(GE_PLUGIN_VERSION), params);
             setParameter(CCUD_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(CCUD_PLUGIN_VERSION), params);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
@@ -37,8 +37,8 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM;
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER;
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL_CONFIG_PARAM;
 
 /**
  * This implementation of {@link BuildParametersProvider} injects configuration parameters and environment variables
@@ -60,7 +60,7 @@ public final class GradleEnterpriseParametersProvider implements BuildParameters
             setParameter(GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM, connectionParams.get(GRADLE_PLUGIN_REPOSITORY_URL), params);
             setParameter(GRADLE_ENTERPRISE_URL_CONFIG_PARAM, connectionParams.get(GRADLE_ENTERPRISE_URL), params);
             setParameter(ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM, connectionParams.get(ALLOW_UNTRUSTED_SERVER), params);
-            setParameter(OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM, connectionParams.get(OVERRIDE_EXISTING_SERVER), params);
+            setParameter(ENFORCE_URL_CONFIG_PARAM, connectionParams.get(ENFORCE_URL), params);
             setParameter(GE_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(GE_PLUGIN_VERSION), params);
             setParameter(CCUD_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(CCUD_PLUGIN_VERSION), params);
             setParameter(GE_EXTENSION_VERSION_CONFIG_PARAM, connectionParams.get(GE_EXTENSION_VERSION), params);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
@@ -59,8 +59,8 @@ public final class GradleEnterpriseParametersProvider implements BuildParameters
             Map<String, String> connectionParams = connections.get(i);
             setParameter(GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM, connectionParams.get(GRADLE_PLUGIN_REPOSITORY_URL), params);
             setParameter(GRADLE_ENTERPRISE_URL_CONFIG_PARAM, connectionParams.get(GRADLE_ENTERPRISE_URL), params);
-            setParameter(OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM, connectionParams.get(OVERRIDE_EXISTING_SERVER), params);
             setParameter(ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM, connectionParams.get(ALLOW_UNTRUSTED_SERVER), params);
+            setParameter(OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM, connectionParams.get(OVERRIDE_EXISTING_SERVER), params);
             setParameter(GE_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(GE_PLUGIN_VERSION), params);
             setParameter(CCUD_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(CCUD_PLUGIN_VERSION), params);
             setParameter(GE_EXTENSION_VERSION_CONFIG_PARAM, connectionParams.get(GE_EXTENSION_VERSION), params);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
@@ -37,8 +37,8 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP;
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM;
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL;
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL_CONFIG_PARAM;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_GRADLE_ENTERPRISE_URL;
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM;
 
 /**
  * This implementation of {@link BuildParametersProvider} injects configuration parameters and environment variables
@@ -60,7 +60,7 @@ public final class GradleEnterpriseParametersProvider implements BuildParameters
             setParameter(GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM, connectionParams.get(GRADLE_PLUGIN_REPOSITORY_URL), params);
             setParameter(GRADLE_ENTERPRISE_URL_CONFIG_PARAM, connectionParams.get(GRADLE_ENTERPRISE_URL), params);
             setParameter(ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM, connectionParams.get(ALLOW_UNTRUSTED_SERVER), params);
-            setParameter(ENFORCE_URL_CONFIG_PARAM, connectionParams.get(ENFORCE_URL), params);
+            setParameter(ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM, connectionParams.get(ENFORCE_GRADLE_ENTERPRISE_URL), params);
             setParameter(GE_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(GE_PLUGIN_VERSION), params);
             setParameter(CCUD_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(CCUD_PLUGIN_VERSION), params);
             setParameter(GE_EXTENSION_VERSION_CONFIG_PARAM, connectionParams.get(GE_EXTENSION_VERSION), params);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
@@ -60,7 +60,6 @@ public final class GradleEnterpriseParametersProvider implements BuildParameters
             setParameter(GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM, connectionParams.get(GRADLE_PLUGIN_REPOSITORY_URL), params);
             setParameter(GRADLE_ENTERPRISE_URL_CONFIG_PARAM, connectionParams.get(GRADLE_ENTERPRISE_URL), params);
             setParameter(ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM, connectionParams.get(ALLOW_UNTRUSTED_SERVER), params);
-            setParameter(ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM, connectionParams.get(ENFORCE_GRADLE_ENTERPRISE_URL), params);
             setParameter(GE_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(GE_PLUGIN_VERSION), params);
             setParameter(CCUD_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(CCUD_PLUGIN_VERSION), params);
             setParameter(GE_EXTENSION_VERSION_CONFIG_PARAM, connectionParams.get(GE_EXTENSION_VERSION), params);
@@ -69,6 +68,7 @@ public final class GradleEnterpriseParametersProvider implements BuildParameters
             setParameter(CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM, connectionParams.get(CUSTOM_CCUD_EXTENSION_COORDINATES), params);
             setParameter(INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM, connectionParams.get(INSTRUMENT_COMMAND_LINE_BUILD_STEP), params);
             setParameter(GRADLE_ENTERPRISE_ACCESS_KEY_ENV_VAR, connectionParams.get(GRADLE_ENTERPRISE_ACCESS_KEY), params);
+            setParameter(ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM, connectionParams.get(ENFORCE_GRADLE_ENTERPRISE_URL), params);
         }
         return params;
     }

--- a/src/main/resources/buildServerResources/geConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/geConnectionDialog.jsp
@@ -43,9 +43,9 @@
 </tr>
 
 <tr>
-    <td><label for="${keys.enforceUrl}">Enforce Gradle Enterprise Server URL:</label></td>
+    <td><label for="${keys.enforceGradleEnterpriseUrl}">Enforce Gradle Enterprise Server URL:</label></td>
     <td>
-        <props:checkboxProperty name="${keys.enforceUrl}"/>
+        <props:checkboxProperty name="${keys.enforceGradleEnterpriseUrl}"/>
         <span class="smallNote">Whether to enforce the Gradle Enterprise Server URL configured in this connection over a URL configured in the project's build.</span>
     </td>
 </tr>

--- a/src/main/resources/buildServerResources/geConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/geConnectionDialog.jsp
@@ -34,10 +34,10 @@
 </tr>
 
 <tr>
-    <td><label for="${keys.enforceUrl}">Enforce URL:</label></td>
+    <td><label for="${keys.enforceUrl}">Enforce Gradle Enterprise Server URL:</label></td>
     <td>
         <props:checkboxProperty name="${keys.enforceUrl}"/>
-        <span class="smallNote">Whether to enforce the Gradle Enterprise URL configured in this connection over a URL configured by the project.</span>
+        <span class="smallNote">Whether to enforce the Gradle Enterprise Server URL configured in this connection over a URL configured in the project's build.</span>
     </td>
 </tr>
 

--- a/src/main/resources/buildServerResources/geConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/geConnectionDialog.jsp
@@ -34,19 +34,19 @@
 </tr>
 
 <tr>
-    <td><label for="${keys.enforceUrl}">Enforce Gradle Enterprise Server URL:</label></td>
-    <td>
-        <props:checkboxProperty name="${keys.enforceUrl}"/>
-        <span class="smallNote">Whether to enforce the Gradle Enterprise Server URL configured in this connection over a URL configured in the project's build.</span>
-    </td>
-</tr>
-
-<tr>
     <td><label for="${keys.gradleEnterpriseAccessKey}">Gradle Enterprise Access Key:</label></td>
     <td>
         <props:passwordProperty name="${keys.gradleEnterpriseAccessKey}" className="longField"/>
         <span class="error" id="error_${keys.gradleEnterpriseAccessKey}"></span>
         <span class="smallNote">The access key for authenticating with the Gradle Enterprise server.</span>
+    </td>
+</tr>
+
+<tr>
+    <td><label for="${keys.enforceUrl}">Enforce Gradle Enterprise Server URL:</label></td>
+    <td>
+        <props:checkboxProperty name="${keys.enforceUrl}"/>
+        <span class="smallNote">Whether to enforce the Gradle Enterprise Server URL configured in this connection over a URL configured in the project's build.</span>
     </td>
 </tr>
 

--- a/src/main/resources/buildServerResources/geConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/geConnectionDialog.jsp
@@ -34,10 +34,10 @@
 </tr>
 
 <tr>
-    <td><label for="${keys.allowUntrustedServer}">Override Configured Server:</label></td>
+    <td><label for="${keys.enforceUrl}">Enforce URL:</label></td>
     <td>
-        <props:checkboxProperty name="${keys.overrideExistingServer}"/>
-        <span class="smallNote">Whether a Gradle Enterprise Server configured by the project should be overridden by the url configured by this connection.</span>
+        <props:checkboxProperty name="${keys.enforceUrl}"/>
+        <span class="smallNote">Whether to enforce the Gradle Enterprise URL configured in this connection over a URL configured by the project.</span>
     </td>
 </tr>
 

--- a/src/main/resources/buildServerResources/geConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/geConnectionDialog.jsp
@@ -34,6 +34,14 @@
 </tr>
 
 <tr>
+    <td><label for="${keys.allowUntrustedServer}">Override Configured Server:</label></td>
+    <td>
+        <props:checkboxProperty name="${keys.overrideExistingServer}"/>
+        <span class="smallNote">Whether a Gradle Enterprise Server configured by the project should be overridden by the url configured by this connection.</span>
+    </td>
+</tr>
+
+<tr>
     <td><label for="${keys.gradleEnterpriseAccessKey}">Gradle Enterprise Access Key:</label></td>
     <td>
         <props:passwordProperty name="${keys.gradleEnterpriseAccessKey}" className="longField"/>

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProviderTest.groovy
@@ -32,6 +32,8 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM
 
 @Unroll
 class GradleEnterpriseParametersProviderTest extends Specification {
@@ -114,6 +116,7 @@ class GradleEnterpriseParametersProviderTest extends Specification {
         GRADLE_PLUGIN_REPOSITORY_URL       | GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM       | 'https://plugins.example.com'
         GRADLE_ENTERPRISE_URL              | GRADLE_ENTERPRISE_URL_CONFIG_PARAM              | 'https://ge.example.com'
         ALLOW_UNTRUSTED_SERVER             | ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM             | 'true'
+        OVERRIDE_EXISTING_SERVER           | OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM       | 'true'
         GE_PLUGIN_VERSION                  | GE_PLUGIN_VERSION_CONFIG_PARAM                  | '1.0.0'
         CCUD_PLUGIN_VERSION                | CCUD_PLUGIN_VERSION_CONFIG_PARAM                | '1.0.0'
         GE_EXTENSION_VERSION               | GE_EXTENSION_VERSION_CONFIG_PARAM               | '1.0.0'

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProviderTest.groovy
@@ -32,8 +32,8 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL_CONFIG_PARAM
 
 @Unroll
 class GradleEnterpriseParametersProviderTest extends Specification {
@@ -116,7 +116,7 @@ class GradleEnterpriseParametersProviderTest extends Specification {
         GRADLE_PLUGIN_REPOSITORY_URL       | GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM       | 'https://plugins.example.com'
         GRADLE_ENTERPRISE_URL              | GRADLE_ENTERPRISE_URL_CONFIG_PARAM              | 'https://ge.example.com'
         ALLOW_UNTRUSTED_SERVER             | ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM             | 'true'
-        OVERRIDE_EXISTING_SERVER           | OVERRIDE_EXISTING_SERVER_URL_CONFIG_PARAM       | 'true'
+        ENFORCE_URL                        | ENFORCE_URL_CONFIG_PARAM                        | 'true'
         GE_PLUGIN_VERSION                  | GE_PLUGIN_VERSION_CONFIG_PARAM                  | '1.0.0'
         CCUD_PLUGIN_VERSION                | CCUD_PLUGIN_VERSION_CONFIG_PARAM                | '1.0.0'
         GE_EXTENSION_VERSION               | GE_EXTENSION_VERSION_CONFIG_PARAM               | '1.0.0'

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProviderTest.groovy
@@ -32,8 +32,8 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP
 import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL
-import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_URL_CONFIG_PARAM
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_GRADLE_ENTERPRISE_URL
+import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnectionConstants.ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM
 
 @Unroll
 class GradleEnterpriseParametersProviderTest extends Specification {
@@ -116,7 +116,7 @@ class GradleEnterpriseParametersProviderTest extends Specification {
         GRADLE_PLUGIN_REPOSITORY_URL       | GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM       | 'https://plugins.example.com'
         GRADLE_ENTERPRISE_URL              | GRADLE_ENTERPRISE_URL_CONFIG_PARAM              | 'https://ge.example.com'
         ALLOW_UNTRUSTED_SERVER             | ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM             | 'true'
-        ENFORCE_URL                        | ENFORCE_URL_CONFIG_PARAM                        | 'true'
+        ENFORCE_GRADLE_ENTERPRISE_URL      | ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM      | 'true'
         GE_PLUGIN_VERSION                  | GE_PLUGIN_VERSION_CONFIG_PARAM                  | '1.0.0'
         CCUD_PLUGIN_VERSION                | CCUD_PLUGIN_VERSION_CONFIG_PARAM                | '1.0.0'
         GE_EXTENSION_VERSION               | GE_EXTENSION_VERSION_CONFIG_PARAM               | '1.0.0'


### PR DESCRIPTION
This PR adds a checkbox to the configuration UI to allow the GE URL configuration in the TeamCity Build Scan Plugin to override the values configured in projects. This may be useful for migrating projects from one server to another. In particular, it can be useful for projects that are already configured to upload scans to scans.gradle.com.

The behavior of this PR is that the values for GE URL and Allow Untrusted Server configured in the TeamCity Build Scan Plugin connection dialog will overwrite those found in the project when:
* GE version is configured
* The new override checkbox is enabled