### PR TITLE
Use Gradle Enterprise Gradle plugin version 3.13.3 by default

### DIFF
--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
@@ -154,7 +154,7 @@ class BaseInitScriptTest extends Specification {
         } else {
             """
               plugins {
-                id 'com.gradle.enterprise' version '3.13.2'
+                id 'com.gradle.enterprise' version '3.13.3'
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
               gradleEnterprise {
@@ -182,7 +182,7 @@ class BaseInitScriptTest extends Specification {
         } else if (gradleVersion < GradleVersion.version('6.0')) {
             """
               plugins {
-                id 'com.gradle.build-scan' version '3.13.2'
+                id 'com.gradle.build-scan' version '3.13.3'
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
               gradleEnterprise {

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
@@ -8,7 +8,7 @@ import static org.junit.Assume.assumeTrue
 
 class GEPluginApplicationInitScriptTest extends BaseInitScriptTest {
 
-    private static final String GE_PLUGIN_VERSION = '3.13.2'
+    private static final String GE_PLUGIN_VERSION = '3.13.3'
     private static final String CCUD_PLUGIN_VERSION = '1.10'
 
     private static final GradleVersion GRADLE_6 = GradleVersion.version('6.0')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.13.2'
+    id 'com.gradle.enterprise' version '3.13.3'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
 }

--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
-gradleEnterprisePluginVersion=3.13.2
+gradleEnterprisePluginVersion=3.13.3
 commonCustomUserDataPluginVersion=1.10
 gradleEnterpriseExtensionVersion=1.17.2
 commonCustomUserDataExtensionVersion=1.11.1

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
@@ -59,7 +59,7 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         GRADLE_PLUGIN_REPOSITORY_URL       | 'https://plugins.example.com'   | 'Gradle Plugin Repository URL'
         GRADLE_ENTERPRISE_URL              | 'https://ge.example.com'        | 'Gradle Enterprise Server URL'
         ALLOW_UNTRUSTED_SERVER             | 'true'                          | 'Allow Untrusted Server'
-        GE_PLUGIN_VERSION                  | '3.13.2'                        | 'Gradle Enterprise Gradle Plugin Version'
+        GE_PLUGIN_VERSION                  | '3.13.3'                        | 'Gradle Enterprise Gradle Plugin Version'
         CCUD_PLUGIN_VERSION                | '1.10'                          | 'Common Custom User Data Gradle Plugin Version'
         GE_EXTENSION_VERSION               | '1.17.2'                        | 'Gradle Enterprise Maven Extension Version'
         CCUD_EXTENSION_VERSION             | '1.11.1'                        | 'Common Custom User Data Maven Extension Version'


### PR DESCRIPTION
This PR bumps the default version of the Gradle Enterprise Gradle plugin version to 3.13.3.