### PR TITLE
Bump Common Custom User Data Maven extension version from 1.11.1 to 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ For Maven builds, the version of the Gradle Enterprise Maven extension automatic
 | TC Build Scan plugin version | Injected GE Maven extension version | Injected Common CCUD Maven extension version |
 |------------------------------|-------------------------------------|----------------------------------------------|
 | Next                         | 1.17.2                              | 1.12                                         |
-| 0.33                         | 1.16.1                              | 1.12                                         |
-| 0.32                         | 1.15.4                              | 1.12                                         |
-| 0.31                         | 1.15.3                              | 1.12                                         |
+| 0.33                         | 1.16.1                              | 1.11.1                                       |
+| 0.32                         | 1.15.4                              | 1.11.1                                       |
+| 0.31                         | 1.15.3                              | 1.11.1                                       |
 | 0.30                         | 1.15.1                              | 1.11                                         |
 | 0.27 - 0.29                  | 1.14.3                              | 1.10.1                                       |
 | 0.25 - 0.26                  | 1.14.2                              | 1.10.1                                       |

--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ For Maven builds, the version of the Gradle Enterprise Maven extension automatic
 
 | TC Build Scan plugin version | Injected GE Maven extension version | Injected Common CCUD Maven extension version |
 |------------------------------|-------------------------------------|----------------------------------------------|
-| Next                         | 1.17.2                              | 1.11.1                                       |
-| 0.33                         | 1.16.1                              | 1.11.1                                       |
-| 0.32                         | 1.15.4                              | 1.11.1                                       |
-| 0.31                         | 1.15.3                              | 1.11.1                                       |
+| Next                         | 1.17.2                              | 1.12                                         |
+| 0.33                         | 1.16.1                              | 1.12                                         |
+| 0.32                         | 1.15.4                              | 1.12                                         |
+| 0.31                         | 1.15.3                              | 1.12                                         |
 | 0.30                         | 1.15.1                              | 1.11                                         |
 | 0.27 - 0.29                  | 1.14.3                              | 1.10.1                                       |
 | 0.25 - 0.26                  | 1.14.2                              | 1.10.1                                       |

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -17,7 +17,7 @@ configurations {
 dependencies {
     mvnExtensions project(path: ':agent:service-message-maven-extension', configuration: 'mvnExtension')
     mvnExtensions 'com.gradle:gradle-enterprise-maven-extension:1.17.2'
-    mvnExtensions 'com.gradle:common-custom-user-data-maven-extension:1.11.1'
+    mvnExtensions 'com.gradle:common-custom-user-data-maven-extension:1.12'
 
     testImplementation gradleTestKit()
     testImplementation ('io.ratpack:ratpack-groovy-test:1.10.0-milestone-10') {

--- a/agent/service-message-maven-extension/.mvn/extensions.xml
+++ b/agent/service-message-maven-extension/.mvn/extensions.xml
@@ -8,6 +8,6 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>1.11.1</version>
+        <version>1.12</version>
     </extension>
 </extensions>

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -43,7 +43,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";
     private static final String BUILD_SCAN_EXT_MAVEN = "service-message-maven-extension-1.0.jar";
     private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.17.2.jar";
-    private static final String COMMON_CUSTOM_USER_DATA_EXT_MAVEN = "common-custom-user-data-maven-extension-1.11.1.jar";
+    private static final String COMMON_CUSTOM_USER_DATA_EXT_MAVEN = "common-custom-user-data-maven-extension-1.12.jar";
 
     // TeamCity Command-line runner
 

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/BaseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/BaseExtensionApplicationTest.groovy
@@ -39,7 +39,7 @@ class BaseExtensionApplicationTest extends Specification {
     static final String GE_URL_STR = System.getenv('GRADLE_ENTERPRISE_TEST_INSTANCE')
     static final URI GE_URL = GE_URL_STR ? new URI(GE_URL_STR) : null
     static final String GE_EXTENSION_VERSION = '1.17.2'
-    static final String CCUD_EXTENSION_VERSION = '1.11.1'
+    static final String CCUD_EXTENSION_VERSION = '1.12'
 
     @TempDir
     File checkoutDir

--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
 gradleEnterprisePluginVersion=3.13.3
 commonCustomUserDataPluginVersion=1.10
 gradleEnterpriseExtensionVersion=1.17.2
-commonCustomUserDataExtensionVersion=1.11.1
+commonCustomUserDataExtensionVersion=1.12

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
@@ -62,7 +62,7 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         GE_PLUGIN_VERSION                  | '3.13.3'                        | 'Gradle Enterprise Gradle Plugin Version'
         CCUD_PLUGIN_VERSION                | '1.10'                          | 'Common Custom User Data Gradle Plugin Version'
         GE_EXTENSION_VERSION               | '1.17.2'                        | 'Gradle Enterprise Maven Extension Version'
-        CCUD_EXTENSION_VERSION             | '1.11.1'                        | 'Common Custom User Data Maven Extension Version'
+        CCUD_EXTENSION_VERSION             | '1.12'                          | 'Common Custom User Data Maven Extension Version'
         CUSTOM_GE_EXTENSION_COORDINATES    | 'com.company:my-ge-extension'   | 'Gradle Enterprise Maven Extension Custom Coordinates'
         CUSTOM_CCUD_EXTENSION_COORDINATES  | 'com.company:my-ccud-extension' | 'Common Custom User Data Maven Extension Custom Coordinates'
         INSTRUMENT_COMMAND_LINE_BUILD_STEP | 'true'                          | 'Instrument Command Line Build Steps'


### PR DESCRIPTION
This PR bumps the Common Custom User Data Maven extension version from 1.11.1 to 1.12.