### PR TITLE
Allow for selection of the previous two previous versions of the Gradle Enterprise Maven Extension

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -8,9 +8,11 @@ repositories {
 }
 
 configurations {
-    mvnExtensions {
-        canBeConsumed = false
-        canBeResolved = true
+    ["mvnExtensions", "geMvnExtensionOnePrevious", "geMvnExtensionTwoPrevious"].each {
+        create(it) {
+            canBeConsumed = false
+            canBeResolved = true
+        }
     }
 }
 
@@ -18,6 +20,8 @@ dependencies {
     mvnExtensions project(path: ':agent:service-message-maven-extension', configuration: 'mvnExtension')
     mvnExtensions 'com.gradle:gradle-enterprise-maven-extension:1.17.2'
     mvnExtensions 'com.gradle:common-custom-user-data-maven-extension:1.12'
+    geMvnExtensionOnePrevious 'com.gradle:gradle-enterprise-maven-extension:1.16.6'
+    geMvnExtensionTwoPrevious 'com.gradle:gradle-enterprise-maven-extension:1.15.5'
 
     testImplementation gradleTestKit()
     testImplementation ('io.ratpack:ratpack-groovy-test:1.10.0-milestone-10') {
@@ -30,6 +34,8 @@ dependencies {
 
 processResources {
     from configurations.mvnExtensions
+    from configurations.geMvnExtensionOnePrevious
+    from configurations.geMvnExtensionTwoPrevious
 }
 
 java {

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -43,7 +43,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";
     private static final MavenCoordinates BUILD_SCAN_EXT_MAVEN = new MavenCoordinates("nu.studer", "service-message-maven-extension", "1.0");
     private static final MavenCoordinates GRADLE_ENTERPRISE_EXT_MAVEN = new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension");
-    private static final MavenCoordinates COMMON_CUSTOM_USER_DATA_EXT_MAVEN = new MavenCoordinates("com.gradle", "common-custom-user-data-maven-extension", "1.12");
+    private static final MavenCoordinates COMMON_CUSTOM_USER_DATA_EXT_MAVEN = new MavenCoordinates("com.gradle", "common-custom-user-data-maven-extension");
 
     // TeamCity Command-line runner
 
@@ -239,7 +239,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
             MavenCoordinates customCcudExtensionCoords = parseCoordinates(getOptionalConfigParam(CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM, runner));
             if (!extensions.hasExtension(COMMON_CUSTOM_USER_DATA_EXT_MAVEN) && !extensions.hasExtension(customCcudExtensionCoords)) {
                 extensionApplicationListener.ccudExtensionApplied(ccudExtensionVersion);
-                extensionJars.add(getExtensionJar(COMMON_CUSTOM_USER_DATA_EXT_MAVEN, runner));
+                extensionJars.add(getExtensionJar(new MavenCoordinates(COMMON_CUSTOM_USER_DATA_EXT_MAVEN, ccudExtensionVersion), runner));
             }
         }
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -41,9 +41,9 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
 
     private static final String MAVEN_RUNNER = "Maven2";
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";
-    private static final String BUILD_SCAN_EXT_MAVEN = "service-message-maven-extension-1.0.jar";
-    private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.17.2.jar";
-    private static final String COMMON_CUSTOM_USER_DATA_EXT_MAVEN = "common-custom-user-data-maven-extension-1.12.jar";
+    private static final MavenCoordinates BUILD_SCAN_EXT_MAVEN = new MavenCoordinates("nu.studer", "service-message-maven-extension", "1.0");
+    private static final MavenCoordinates GRADLE_ENTERPRISE_EXT_MAVEN = new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension", "1.17.2");
+    private static final MavenCoordinates COMMON_CUSTOM_USER_DATA_EXT_MAVEN = new MavenCoordinates("com.gradle", "common-custom-user-data-maven-extension", "1.12");
 
     // TeamCity Command-line runner
 
@@ -82,8 +82,6 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String GE_URL_MAVEN_PROPERTY = "gradle.enterprise.url";
     private static final String GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY = "gradle.enterprise.allowUntrustedServer";
     private static final String GE_EXTENSION_UPLOAD_IN_BACKGROUND_MAVEN_PROPERTY = "gradle.scan.uploadInBackground";
-    private static final MavenCoordinates GE_EXTENSION_MAVEN_COORDINATES = new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension");
-    private static final MavenCoordinates CCUD_EXTENSION_MAVEN_COORDINATES = new MavenCoordinates("com.gradle", "common-custom-user-data-maven-extension");
 
     @NotNull
     private final ExtensionApplicationListener extensionApplicationListener;
@@ -224,7 +222,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
         if (geExtensionVersion != null) {
             MavenCoordinates customGeExtensionCoords = parseCoordinates(getOptionalConfigParam(CUSTOM_GE_EXTENSION_COORDINATES_CONFIG_PARAM, runner));
             String geUrl = getOptionalConfigParam(GE_URL_CONFIG_PARAM, runner);
-            if (!extensions.hasExtension(GE_EXTENSION_MAVEN_COORDINATES) && !extensions.hasExtension(customGeExtensionCoords)) {
+            if (!extensions.hasExtension(GRADLE_ENTERPRISE_EXT_MAVEN) && !extensions.hasExtension(customGeExtensionCoords)) {
                 extensionApplicationListener.geExtensionApplied(geExtensionVersion);
                 extensionJars.add(getExtensionJar(GRADLE_ENTERPRISE_EXT_MAVEN, runner));
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
@@ -239,7 +237,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
         String ccudExtensionVersion = getOptionalConfigParam(CCUD_EXTENSION_VERSION_CONFIG_PARAM, runner);
         if (ccudExtensionVersion != null) {
             MavenCoordinates customCcudExtensionCoords = parseCoordinates(getOptionalConfigParam(CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM, runner));
-            if (!extensions.hasExtension(CCUD_EXTENSION_MAVEN_COORDINATES) && !extensions.hasExtension(customCcudExtensionCoords)) {
+            if (!extensions.hasExtension(COMMON_CUSTOM_USER_DATA_EXT_MAVEN) && !extensions.hasExtension(customCcudExtensionCoords)) {
                 extensionApplicationListener.ccudExtensionApplied(ccudExtensionVersion);
                 extensionJars.add(getExtensionJar(COMMON_CUSTOM_USER_DATA_EXT_MAVEN, runner));
             }
@@ -248,9 +246,10 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
         return "-Dmaven.ext.class.path=" + asClasspath(extensionJars) + " " + asArgs(sysProps);
     }
 
-    private File getExtensionJar(String name, BuildRunnerContext runner) {
-        File extensionJar = new File(runner.getBuild().getAgentTempDirectory(), name);
-        FileUtil.copyResourceIfNotExists(BuildScanServiceMessageInjector.class, "/" + name, extensionJar);
+    private File getExtensionJar(MavenCoordinates extension, BuildRunnerContext runner) {
+        String extensionFileName = extension.toFileName();
+        File extensionJar = new File(runner.getBuild().getAgentTempDirectory(), extensionFileName);
+        FileUtil.copyResourceIfNotExists(BuildScanServiceMessageInjector.class, "/" + extensionFileName, extensionJar);
         return extensionJar;
     }
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -42,7 +42,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String MAVEN_RUNNER = "Maven2";
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";
     private static final MavenCoordinates BUILD_SCAN_EXT_MAVEN = new MavenCoordinates("nu.studer", "service-message-maven-extension", "1.0");
-    private static final MavenCoordinates GRADLE_ENTERPRISE_EXT_MAVEN = new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension", "1.17.2");
+    private static final MavenCoordinates GRADLE_ENTERPRISE_EXT_MAVEN = new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension");
     private static final MavenCoordinates COMMON_CUSTOM_USER_DATA_EXT_MAVEN = new MavenCoordinates("com.gradle", "common-custom-user-data-maven-extension", "1.12");
 
     // TeamCity Command-line runner
@@ -224,7 +224,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
             String geUrl = getOptionalConfigParam(GE_URL_CONFIG_PARAM, runner);
             if (!extensions.hasExtension(GRADLE_ENTERPRISE_EXT_MAVEN) && !extensions.hasExtension(customGeExtensionCoords)) {
                 extensionApplicationListener.geExtensionApplied(geExtensionVersion);
-                extensionJars.add(getExtensionJar(GRADLE_ENTERPRISE_EXT_MAVEN, runner));
+                extensionJars.add(getExtensionJar(new MavenCoordinates(GRADLE_ENTERPRISE_EXT_MAVEN, geExtensionVersion), runner));
                 addSysPropIfSet(GE_URL_CONFIG_PARAM, GE_URL_MAVEN_PROPERTY, sysProps, runner);
                 addSysPropIfSet(GE_ALLOW_UNTRUSTED_CONFIG_PARAM, GE_ALLOW_UNTRUSTED_MAVEN_PROPERTY, sysProps, runner);
                 addSysProp(GE_EXTENSION_UPLOAD_IN_BACKGROUND_MAVEN_PROPERTY, "false", sysProps);

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/MavenCoordinates.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/MavenCoordinates.java
@@ -21,6 +21,10 @@ final class MavenCoordinates {
         this.version = version;
     }
 
+    MavenCoordinates(MavenCoordinates mavenCoordinates, String version) {
+        this(mavenCoordinates.groupId, mavenCoordinates.artifactId, version);
+    }
+
     String getGroupId() {
         return groupId;
     }

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/MavenCoordinates.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/MavenCoordinates.java
@@ -33,6 +33,10 @@ final class MavenCoordinates {
         return version;
     }
 
+    public String toFileName() {
+        return String.format("%s-%s.jar", artifactId, version);
+    }
+
     @Override
     public String toString() {
         return String.format("%s:%s:%s", groupId, artifactId, version);

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/PreviousExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/PreviousExtensionApplicationTest.groovy
@@ -1,0 +1,39 @@
+package nu.studer.teamcity.buildscan.agent.maven
+
+import nu.studer.teamcity.buildscan.agent.TcPluginConfig
+import nu.studer.teamcity.buildscan.agent.maven.testutils.MavenProject
+
+import static org.junit.Assume.assumeTrue
+
+class PreviousExtensionApplicationTest extends BaseExtensionApplicationTest {
+    static final String GE_EXTENSION_VERSION_ONE_PREVIOUS = '1.16.6'
+    static final String GE_EXTENSION_VERSION_TWO_PREVIOUS = '1.15.5'
+
+    def "applies previous versions GE extension via classpath when not defined in project (#jdkCompatibleMavenVersion, GE Maven Extension #geExtensionVersion)"() {
+        assumeTrue jdkCompatibleMavenVersion.isJvmVersionCompatible()
+        assumeTrue GE_URL != null
+
+        given:
+        def mvnProject = new MavenProject.Configuration().buildIn(checkoutDir)
+
+        and:
+        def gePluginConfig = new TcPluginConfig(
+                geUrl: GE_URL,
+                geExtensionVersion: geExtensionVersion,
+        )
+
+        when:
+        def output = run(jdkCompatibleMavenVersion.mavenVersion, mvnProject, gePluginConfig)
+
+        then:
+        1 * extensionApplicationListener.geExtensionApplied(geExtensionVersion)
+        0 * extensionApplicationListener.ccudExtensionApplied(_)
+
+        and:
+        outputContainsTeamCityServiceMessageBuildStarted(output)
+        outputContainsTeamCityServiceMessageBuildScanUrl(output)
+
+        where:
+        [jdkCompatibleMavenVersion , geExtensionVersion] << [SUPPORTED_MAVEN_VERSIONS, [TWO_PREVIOUS_GE_EXTENSION_VERSION, GE_EXTENSION_VERSION_ONE_PREVIOUS]].combinations()
+    }
+}

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,2 @@
 - Allows to enforce the Gradle Enterprise URL over what might be configured in the project's build
+- Allows to apply the latest patch version of the previous two Gradle Enterprise Maven Extension releases

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -1,5 +1,9 @@
 package nu.studer.teamcity.buildscan.connection;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 @SuppressWarnings("unused")
 public final class GradleEnterpriseConnectionConstants {
 
@@ -34,6 +38,12 @@ public final class GradleEnterpriseConnectionConstants {
     public static final String INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM = "buildScanPlugin.command-line-build-step.enabled";
     public static final String GRADLE_ENTERPRISE_ACCESS_KEY_ENV_VAR = "env.GRADLE_ENTERPRISE_ACCESS_KEY";
     public static final String ENFORCE_GRADLE_ENTERPRISE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.enforce-url";
+
+    // Bundled version constants
+    // These are used to define the versions of the Gradle Enterprise and Common Custom User Data Extensions that are bundle with this plugin
+
+    public static final List<String> BUNDLED_GE_EXTENSION_VERSIONS = Arrays.asList("1.17.2", "1.16.6", "1.15.5");
+    public static final List<String> BUNDLED_CCUD_EXTENSION_VERSIONS = Collections.singletonList("1.11.1");
 
     public static final String GRADLE_ENTERPRISE_CONNECTION_PROVIDER = "gradle-enterprise-connection-provider";
 
@@ -87,4 +97,11 @@ public final class GradleEnterpriseConnectionConstants {
         return ENFORCE_GRADLE_ENTERPRISE_URL;
     }
 
+    public List<String> getGeExtensionVersions() {
+        return BUNDLED_GE_EXTENSION_VERSIONS;
+    }
+
+    public List<String> getCcudExtensionVersions() {
+        return BUNDLED_CCUD_EXTENSION_VERSIONS;
+    }
 }

--- a/src/main/resources/buildServerResources/geConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/geConnectionDialog.jsp
@@ -92,7 +92,12 @@
 <tr>
     <td><label for="${keys.gradleEnterpriseExtensionVersion}">Gradle Enterprise Maven Extension Version:</label></td>
     <td>
-        <props:textProperty name="${keys.gradleEnterpriseExtensionVersion}" className="longField"/>
+        <props:selectProperty name="${keys.gradleEnterpriseExtensionVersion}" className="mediumField">
+            <props:option value="" id="default" />
+            <c:forEach items="${keys.geExtensionVersions}" var="version">
+                <props:option value="${version}" id="gradle-enterprise-maven-extension-${version}">${version}</props:option>
+            </c:forEach>
+        </props:selectProperty>
         <span class="smallNote">The version of the Gradle Enterprise Maven Extension to apply to Maven builds.</span>
     </td>
 </tr>
@@ -100,7 +105,12 @@
 <tr>
     <td><label for="${keys.commonCustomUserDataExtensionVersion}">Common Custom User Data Maven Extension Version:</label></td>
     <td>
-        <props:textProperty name="${keys.commonCustomUserDataExtensionVersion}" className="longField"/>
+        <props:selectProperty name="${keys.commonCustomUserDataExtensionVersion}" className="mediumField">
+            <props:option value="" id="default" />
+            <c:forEach items="${keys.ccudExtensionVersions}" var="version">
+                <props:option value="${version}" id="common-custom-user-data-maven-extension-${version}">${version}</props:option>
+            </c:forEach>
+        </props:selectProperty>
         <span class="smallNote">The version of the Common Custom User Data Maven Extension to apply to Maven builds.</span>
     </td>
 </tr>


### PR DESCRIPTION
This pull request allows the user to select the most recent patch version of the previous two releases of the Gradle Enterprise Maven Extension. For example, as of today where 1.17.3 is the most recent release, 1.15.5 and 1.16.6 are also selectable. This is achieved by bundling all 3 versions of the extension into the agent jar.

This is enforced at the connection UI with a dropdown. By default the dropdown has an empty value selected, but the user can change this to any of the three bundled versions of the Gradle Enterprise Maven Extension.

Since the Common Custom User Data Maven Extension is likewise bundled with the agent jar, the same dropdown UI is used to enforce the user to pick the correct version.