### PR TITLE
Set `gradle.enterprise.externally-applied` before applying GE plugin

### DIFF
--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -194,15 +194,16 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 }
 
 void applyPluginExternally(PluginManager pluginManager, String pluginClassName) {
-    def oldValue = System.getProperty('gradle.enterprise.externally-applied')
-    System.setProperty('gradle.enterprise.externally-applied', 'true')
+    def propertyName = 'gradle.enterprise.externally-applied'
+    def oldValue = System.getProperty(propertyName)
+    System.setProperty(propertyName, 'true')
     try {
         pluginManager.apply(initscript.classLoader.loadClass(pluginClassName))
     } finally {
         if (oldValue == null) {
-            System.clearProperty('gradle.enterprise.externally-applied')
+            System.clearProperty(propertyName)
         } else {
-            System.setProperty('gradle.enterprise.externally-applied', oldValue)
+            System.setProperty(propertyName, oldValue)
         }
     }
 }

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -193,14 +193,6 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
     }
 }
 
-static def extensionsWithPublicType(def container, String publicType) {
-    container.extensions.extensionsSchema.elements.findAll { it.publicType.concreteClass.name == publicType }
-}
-
-static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
-    GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
-}
-
 void applyPluginExternally(PluginManager pluginManager, String pluginClassName) {
     def oldValue = System.getProperty('gradle.enterprise.externally-applied')
     System.setProperty('gradle.enterprise.externally-applied', 'true')
@@ -213,6 +205,14 @@ void applyPluginExternally(PluginManager pluginManager, String pluginClassName) 
             System.setProperty('gradle.enterprise.externally-applied', oldValue)
         }
     }
+}
+
+static def extensionsWithPublicType(def container, String publicType) {
+    container.extensions.extensionsSchema.elements.findAll { it.publicType.concreteClass.name == publicType }
+}
+
+static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
+    GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
 }
 
 class BuildScanLifeCycleLogger {

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -120,7 +120,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (!scanPluginComponent) {
                     logger.quiet("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                    pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
+                    applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
@@ -161,7 +161,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
                 logger.quiet("Applying $GRADLE_ENTERPRISE_PLUGIN_CLASS via init script")
                 logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
+                applyPluginExternally(settings.pluginManager, GRADLE_ENTERPRISE_PLUGIN_CLASS)
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
@@ -201,6 +201,20 @@ static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
     GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
 }
 
+void applyPluginExternally(PluginManager pluginManager, String pluginClassName) {
+    def oldValue = System.getProperty('gradle.enterprise.externally-applied')
+    System.setProperty('gradle.enterprise.externally-applied', 'true')
+    try {
+        pluginManager.apply(initscript.classLoader.loadClass(pluginClassName))
+    } finally {
+        if (oldValue == null) {
+            System.clearProperty('gradle.enterprise.externally-applied')
+        } else {
+            System.setProperty('gradle.enterprise.externally-applied', oldValue)
+        }
+    }
+}
+
 class BuildScanLifeCycleLogger {
 
     def logger
@@ -235,4 +249,3 @@ class BuildScanLifeCycleLogger {
     }
 
 }
-

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -194,16 +194,16 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 }
 
 void applyPluginExternally(PluginManager pluginManager, String pluginClassName) {
-    def propertyName = 'gradle.enterprise.externally-applied'
-    def oldValue = System.getProperty(propertyName)
-    System.setProperty(propertyName, 'true')
+    def externallyApplied = 'gradle.enterprise.externally-applied'
+    def oldValue = System.getProperty(externallyApplied)
+    System.setProperty(externallyApplied, 'true')
     try {
         pluginManager.apply(initscript.classLoader.loadClass(pluginClassName))
     } finally {
         if (oldValue == null) {
-            System.clearProperty(propertyName)
+            System.clearProperty(externallyApplied)
         } else {
-            System.setProperty(propertyName, oldValue)
+            System.setProperty(externallyApplied, oldValue)
         }
     }
 }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- Informs the GE plugin that it is being applied externally.
+- Informs the Gradle Enterprise Gradle plugin that it is being applied externally.

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- Informs the GE plugin that it is being applied externally
+- Informs the GE plugin that it is being applied externally.

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- TBD
+- Informs the GE plugin that it is being applied externally


### PR DESCRIPTION
In order for the Gradle Enterprise plugin to deactivate any potentially build-changing features (at the time of writing that means all of its testing features) when applied via the init script rather than directly in the build, the `gradle.enterprise.externally-applied` system property is now set before applying it and reset afterwards.