### PR TITLE
Bumped Gradle Enterprise Gradle Plugin from 3.14.1 to 3.15

### DIFF
--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
@@ -157,7 +157,7 @@ class BaseInitScriptTest extends Specification {
         } else {
             """
               plugins {
-                id 'com.gradle.enterprise' version '3.14.1'
+                id 'com.gradle.enterprise' version '3.15'
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
               gradleEnterprise {
@@ -185,7 +185,7 @@ class BaseInitScriptTest extends Specification {
         } else if (gradleVersion < GradleVersion.version('6.0')) {
             """
               plugins {
-                id 'com.gradle.build-scan' version '3.14.1'
+                id 'com.gradle.build-scan' version '3.15'
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
               gradleEnterprise {

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
@@ -8,7 +8,7 @@ import static org.junit.Assume.assumeTrue
 
 class GEPluginApplicationInitScriptTest extends BaseInitScriptTest {
 
-    private static final String GE_PLUGIN_VERSION = '3.14.1'
+    private static final String GE_PLUGIN_VERSION = '3.15'
     private static final String CCUD_PLUGIN_VERSION = '1.11.1'
 
     private static final GradleVersion GRADLE_6 = GradleVersion.version('6.0')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.14.1'
+    id 'com.gradle.enterprise' version '3.15'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11.1'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.6.0'
 }

--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
-gradleEnterprisePluginVersion=3.14.1
+gradleEnterprisePluginVersion=3.15
 commonCustomUserDataPluginVersion=1.11.1
 gradleEnterpriseExtensionVersion=1.18.1
 commonCustomUserDataExtensionVersion=1.12.2

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
@@ -59,7 +59,7 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         GRADLE_PLUGIN_REPOSITORY_URL       | 'https://plugins.example.com'   | 'Gradle Plugin Repository URL'
         GRADLE_ENTERPRISE_URL              | 'https://ge.example.com'        | 'Gradle Enterprise Server URL'
         ALLOW_UNTRUSTED_SERVER             | 'true'                          | 'Allow Untrusted Server'
-        GE_PLUGIN_VERSION                  | '3.14.1'                        | 'Gradle Enterprise Gradle Plugin Version'
+        GE_PLUGIN_VERSION                  | '3.15'                        | 'Gradle Enterprise Gradle Plugin Version'
         CCUD_PLUGIN_VERSION                | '1.11.1'                        | 'Common Custom User Data Gradle Plugin Version'
         GE_EXTENSION_VERSION               | '1.18.1'                        | 'Gradle Enterprise Maven Extension Version'
         CCUD_EXTENSION_VERSION             | '1.12.2'                        | 'Common Custom User Data Maven Extension Version'


### PR DESCRIPTION
Bumped Gradle Enterprise Gradle Plugin from 3.14.1 to 3.15. [Changelog](https://docs.gradle.com/enterprise/gradle-plugin/#release_history)