### PR TITLE
Bumped Gradle Enterprise Maven Extension from 1.18.1 to 1.19.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For Maven builds, the version of the Gradle Enterprise Maven extension automatic
 
 | TC Build Scan plugin version | Injected GE Maven extension version | Injected Common CCUD Maven extension version |
 |------------------------------|-------------------------------------|----------------------------------------------|
-| Next                         | 1.19                              | 1.12.2                                       |
+| Next                         | 1.19.1                              | 1.12.2                                       |
 | 0.35                         | 1.18.1                              | 1.12.2                                       |
 | 0.34                         | 1.18                                | 1.12.2                                       |
 | 0.33                         | 1.16.1                              | 1.11.1                                       |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For Maven builds, the version of the Gradle Enterprise Maven extension automatic
 
 | TC Build Scan plugin version | Injected GE Maven extension version | Injected Common CCUD Maven extension version |
 |------------------------------|-------------------------------------|----------------------------------------------|
-| Next                         | 1.18.1                              | 1.12.2                                       |
+| Next                         | 1.19                              | 1.12.2                                       |
 | 0.35                         | 1.18.1                              | 1.12.2                                       |
 | 0.34                         | 1.18                                | 1.12.2                                       |
 | 0.33                         | 1.16.1                              | 1.11.1                                       |

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -16,7 +16,7 @@ configurations {
 
 dependencies {
     mvnExtensions project(path: ':agent:service-message-maven-extension', configuration: 'mvnExtension')
-    mvnExtensions 'com.gradle:gradle-enterprise-maven-extension:1.18.1'
+    mvnExtensions 'com.gradle:gradle-enterprise-maven-extension:1.19'
     mvnExtensions 'com.gradle:common-custom-user-data-maven-extension:1.12.2'
 
     testImplementation gradleTestKit()

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -16,7 +16,7 @@ configurations {
 
 dependencies {
     mvnExtensions project(path: ':agent:service-message-maven-extension', configuration: 'mvnExtension')
-    mvnExtensions 'com.gradle:gradle-enterprise-maven-extension:1.19'
+    mvnExtensions 'com.gradle:gradle-enterprise-maven-extension:1.19.1'
     mvnExtensions 'com.gradle:common-custom-user-data-maven-extension:1.12.2'
 
     testImplementation gradleTestKit()

--- a/agent/service-message-maven-extension/.mvn/extensions.xml
+++ b/agent/service-message-maven-extension/.mvn/extensions.xml
@@ -3,7 +3,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.19</version>
+        <version>1.19.1</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>

--- a/agent/service-message-maven-extension/.mvn/extensions.xml
+++ b/agent/service-message-maven-extension/.mvn/extensions.xml
@@ -3,7 +3,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.18.1</version>
+        <version>1.19</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>

--- a/agent/service-message-maven-extension/pom.xml
+++ b/agent/service-message-maven-extension/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>gradle-enterprise-maven-extension</artifactId>
-            <version>1.18.1</version>
+            <version>1.19</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/agent/service-message-maven-extension/pom.xml
+++ b/agent/service-message-maven-extension/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>gradle-enterprise-maven-extension</artifactId>
-            <version>1.19</version>
+            <version>1.19.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -42,7 +42,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String MAVEN_RUNNER = "Maven2";
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";
     private static final String BUILD_SCAN_EXT_MAVEN = "service-message-maven-extension-1.0.jar";
-    private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.18.1.jar";
+    private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.19.jar";
     private static final String COMMON_CUSTOM_USER_DATA_EXT_MAVEN = "common-custom-user-data-maven-extension-1.12.2.jar";
 
     // TeamCity Command-line runner

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -42,7 +42,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String MAVEN_RUNNER = "Maven2";
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";
     private static final String BUILD_SCAN_EXT_MAVEN = "service-message-maven-extension-1.0.jar";
-    private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.19.jar";
+    private static final String GRADLE_ENTERPRISE_EXT_MAVEN = "gradle-enterprise-maven-extension-1.19.1.jar";
     private static final String COMMON_CUSTOM_USER_DATA_EXT_MAVEN = "common-custom-user-data-maven-extension-1.12.2.jar";
 
     // TeamCity Command-line runner

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/BaseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/BaseExtensionApplicationTest.groovy
@@ -38,7 +38,7 @@ class BaseExtensionApplicationTest extends Specification {
 
     static final String GE_URL_STR = System.getenv('GRADLE_ENTERPRISE_TEST_INSTANCE')
     static final URI GE_URL = GE_URL_STR ? new URI(GE_URL_STR) : null
-    static final String GE_EXTENSION_VERSION = '1.18.1'
+    static final String GE_EXTENSION_VERSION = '1.19'
     static final String CCUD_EXTENSION_VERSION = '1.12.2'
 
     @TempDir

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/BaseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/BaseExtensionApplicationTest.groovy
@@ -38,7 +38,7 @@ class BaseExtensionApplicationTest extends Specification {
 
     static final String GE_URL_STR = System.getenv('GRADLE_ENTERPRISE_TEST_INSTANCE')
     static final URI GE_URL = GE_URL_STR ? new URI(GE_URL_STR) : null
-    static final String GE_EXTENSION_VERSION = '1.19'
+    static final String GE_EXTENSION_VERSION = '1.19.1'
     static final String CCUD_EXTENSION_VERSION = '1.12.2'
 
     @TempDir

--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
 gradleEnterprisePluginVersion=3.14.1
 commonCustomUserDataPluginVersion=1.11.1
-gradleEnterpriseExtensionVersion=1.18.1
+gradleEnterpriseExtensionVersion=1.19
 commonCustomUserDataExtensionVersion=1.12.2

--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
 gradleEnterprisePluginVersion=3.14.1
 commonCustomUserDataPluginVersion=1.11.1
-gradleEnterpriseExtensionVersion=1.19
+gradleEnterpriseExtensionVersion=1.19.1
 commonCustomUserDataExtensionVersion=1.12.2

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
@@ -61,7 +61,7 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         ALLOW_UNTRUSTED_SERVER             | 'true'                          | 'Allow Untrusted Server'
         GE_PLUGIN_VERSION                  | '3.14.1'                        | 'Gradle Enterprise Gradle Plugin Version'
         CCUD_PLUGIN_VERSION                | '1.11.1'                        | 'Common Custom User Data Gradle Plugin Version'
-        GE_EXTENSION_VERSION               | '1.19'                        | 'Gradle Enterprise Maven Extension Version'
+        GE_EXTENSION_VERSION               | '1.19.1'                        | 'Gradle Enterprise Maven Extension Version'
         CCUD_EXTENSION_VERSION             | '1.12.2'                        | 'Common Custom User Data Maven Extension Version'
         CUSTOM_GE_EXTENSION_COORDINATES    | 'com.company:my-ge-extension'   | 'Gradle Enterprise Maven Extension Custom Coordinates'
         CUSTOM_CCUD_EXTENSION_COORDINATES  | 'com.company:my-ccud-extension' | 'Common Custom User Data Maven Extension Custom Coordinates'

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
@@ -61,7 +61,7 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         ALLOW_UNTRUSTED_SERVER             | 'true'                          | 'Allow Untrusted Server'
         GE_PLUGIN_VERSION                  | '3.14.1'                        | 'Gradle Enterprise Gradle Plugin Version'
         CCUD_PLUGIN_VERSION                | '1.11.1'                        | 'Common Custom User Data Gradle Plugin Version'
-        GE_EXTENSION_VERSION               | '1.18.1'                        | 'Gradle Enterprise Maven Extension Version'
+        GE_EXTENSION_VERSION               | '1.19'                        | 'Gradle Enterprise Maven Extension Version'
         CCUD_EXTENSION_VERSION             | '1.12.2'                        | 'Common Custom User Data Maven Extension Version'
         CUSTOM_GE_EXTENSION_COORDINATES    | 'com.company:my-ge-extension'   | 'Gradle Enterprise Maven Extension Custom Coordinates'
         CUSTOM_CCUD_EXTENSION_COORDINATES  | 'com.company:my-ccud-extension' | 'Common Custom User Data Maven Extension Custom Coordinates'


### PR DESCRIPTION
Bumped Gradle Enterprise Maven Extension from 1.18.1 to 1.19. [Changelog](https://docs.gradle.com/enterprise/maven-extension/#release_history)