### PR TITLE
Bump Maven Wrapper from 3.9.5 to 3.9.6 in /agent/service-message-maven-extension

### DIFF
--- a/agent/service-message-maven-extension/.mvn/wrapper/maven-wrapper.properties
+++ b/agent/service-message-maven-extension/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar


### PR DESCRIPTION
Bumps Maven Wrapper from 3.9.5 to 3.9.6.

Release notes of Maven 3.9.6 can be found here:
https://maven.apache.org/docs/3.9.6/release-notes.html