### PR TITLE
Use an ul when rendering multiple Build Scan®️

### DIFF
--- a/src/main/resources/buildServerResources/buildScanPage.jsp
+++ b/src/main/resources/buildServerResources/buildScanPage.jsp
@@ -4,9 +4,12 @@
 <c:choose>
     <c:when test="${buildScans.size()>1}">
         <div>
-            Build scans
-            <a href="${buildScans.first().url}" target="_blank">${buildScans.first().urlWithoutProtocol}</a><c:forEach items="${buildScans.all()}" var="buildScan" begin="1">,
-            <a href="${buildScan.url}" target="_blank">${buildScan.urlWithoutProtocol}</a></c:forEach> have been published.
+            <h2>Build scans</h2>
+            <ul>
+                <c:forEach items="${buildScans.all()}" var="buildScan">,
+                    <li><a href="${buildScan.url}" target="_blank">${buildScan.urlWithoutProtocol}</a></li>
+                </c:forEach>
+            </ul>
         </div>
     </c:when>
     <c:when test="${!buildScans.isEmpty()}">


### PR DESCRIPTION
This makes it easier to visually parse the links as they clearer better separated.