### PR TITLE
Bump Common Custom User Data Gradle plugin from 1.12.1 to 1.12.2

### DIFF
--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/BaseInitScriptTest.groovy
@@ -145,8 +145,8 @@ class BaseInitScriptTest extends Specification {
     }
 
     def declareGePluginAndCcudPluginApplication(GradleVersion gradleVersion, URI geUrl = mockScansServer.address) {
-        settingsFile << maybeAddPluginsToSettings(gradleVersion, geUrl, '1.12.1')
-        buildFile << maybeAddPluginsToRootProject(gradleVersion, geUrl, '1.12.1')
+        settingsFile << maybeAddPluginsToSettings(gradleVersion, geUrl, '1.12.2')
+        buildFile << maybeAddPluginsToRootProject(gradleVersion, geUrl, '1.12.2')
     }
 
     String maybeAddPluginsToSettings(GradleVersion gradleVersion, URI geUrl, String ccudPluginVersion = null) {

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
@@ -9,7 +9,7 @@ import static org.junit.Assume.assumeTrue
 class GEPluginApplicationInitScriptTest extends BaseInitScriptTest {
 
     private static final String GE_PLUGIN_VERSION = '3.16.1'
-    private static final String CCUD_PLUGIN_VERSION = '1.12.1'
+    private static final String CCUD_PLUGIN_VERSION = '1.12.2'
 
     private static final GradleVersion GRADLE_6 = GradleVersion.version('6.0')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.gradle.enterprise' version '3.16.1'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.12.1'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.12.2'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
 }
 

--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
 gradleEnterprisePluginVersion=3.16.1
-commonCustomUserDataPluginVersion=1.12.1
+commonCustomUserDataPluginVersion=1.12.2
 gradleEnterpriseExtensionVersion=1.20
 commonCustomUserDataExtensionVersion=1.12.5

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
@@ -60,7 +60,7 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         GRADLE_ENTERPRISE_URL              | 'https://ge.example.com'        | 'Gradle Enterprise Server URL'
         ALLOW_UNTRUSTED_SERVER             | 'true'                          | 'Allow Untrusted Server'
         GE_PLUGIN_VERSION                  | '3.16.1'                        | 'Gradle Enterprise Gradle Plugin Version'
-        CCUD_PLUGIN_VERSION                | '1.12.1'                        | 'Common Custom User Data Gradle Plugin Version'
+        CCUD_PLUGIN_VERSION                | '1.12.2'                        | 'Common Custom User Data Gradle Plugin Version'
         GE_EXTENSION_VERSION               | '1.20'                          | 'Gradle Enterprise Maven Extension Version'
         CCUD_EXTENSION_VERSION             | '1.12.5'                        | 'Common Custom User Data Maven Extension Version'
         CUSTOM_GE_EXTENSION_COORDINATES    | 'com.company:my-ge-extension'   | 'Gradle Enterprise Maven Extension Custom Coordinates'


### PR DESCRIPTION
This PR bumps the Common Custom User Data Gradle plugin from `1.12.1` to `1.12.2`.