### PR TITLE
Update user-facing product references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ teamcity-build-scan-plugin
 
 # Overview
 
-[TeamCity](https://www.jetbrains.com/teamcity/) plugin that integrates with the Build Scan service and more generally with Gradle Enterprise for Gradle and Maven builds run via TeamCity. Build scans are available as a free service on [scans.gradle.com](https://scans.gradle.com/) and commercially via [Gradle Enterprise](https://gradle.com/enterprise).
+[TeamCity](https://www.jetbrains.com/teamcity/) plugin that integrates with the Build Scan service and more generally with Develocity for Gradle and Maven builds run via TeamCity. Build scans are available as a free service on [scans.gradle.com](https://scans.gradle.com/) and commercially via [Develocity](https://gradle.com/enterprise).
 
-For each Gradle and Maven build that is run from TeamCity, this plugin exposes the links to the created build scans in the TeamCity UI. The plugin can also be configured to ad-hoc connect Gradle and Maven builds to an existing Gradle Enterprise instance such that a Build Scan is published each time a build is run from TeamCity.
+For each Gradle and Maven build that is run from TeamCity, this plugin exposes the links to the created build scans in the TeamCity UI. The plugin can also be configured to ad-hoc connect Gradle and Maven builds to an existing Develocity instance such that a Build Scan is published each time a build is run from TeamCity.
 
 The plugin is available from the [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/9326-integration-for-gradle-and-maven-build-scans).
 
@@ -57,23 +57,23 @@ If you use TeamCity's _Command Line_ runner to launch your Maven builds, you can
 
 If the first two mechanisms will not work for your Maven build configurations, you can still get integration with build scans, but it requires your build logs being parsed for build scan links. In case of huge build logs, this can put a significant toll on the performance of your TeamCity instance. You can enable the parsing of the build logs by setting the `buildScanPlugin.log-parsing.enabled` configuration parameter to _true_.
 
-## Gradle Enterprise connectivity
+## Develocity connectivity
 
-You can ad-hoc connect Gradle and Maven builds to an existing Gradle Enterprise instance by automatically injecting the [Gradle Enterprise Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) and the [Gradle Enterprise Maven extension](https://docs.gradle.com/enterprise/maven-extension/) when these builds are run via TeamCity's _Gradle_ or _Maven_ runner. If a Gradle or Maven build is run via TeamCity's _Command Line_ runner the auto-injection can be opted in to, too. If a given build is already connected to Gradle Enterprise, the auto-injection is skipped.
+You can ad-hoc connect Gradle and Maven builds to an existing Develocity instance by automatically injecting the [Develocity Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) and the [Develocity Maven extension](https://docs.gradle.com/enterprise/maven-extension/) when these builds are run via TeamCity's _Gradle_ or _Maven_ runner. If a Gradle or Maven build is run via TeamCity's _Command Line_ runner the auto-injection can be opted in to, too. If a given build is already connected to Develocity, the auto-injection is skipped.
 
 The same auto-injection behavior is available for the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) and the [Common Custom User Data Maven extension](https://github.com/gradle/common-custom-user-data-maven-extension).
 
 The higher in TeamCity's project hierarchy the required configuration parameters are applied, the more widely they apply since the configuration parameters are passed on to all child projects. Child projects can override the configuration parameters of their parent projects and even disable the auto-injection by setting the appropriate configuration parameters to empty values.
 
-For convenience, the configuration parameter values can be defined through a form describing a Gradle Enterprise connection. Alternatively, the configuration parameter values can be defined as TeamCity configuration parameters.
+For convenience, the configuration parameter values can be defined through a form describing a Develocity connection. Alternatively, the configuration parameter values can be defined as TeamCity configuration parameters.
 
 ### Configuration via TeamCity connection
 
-A Gradle Enterprise connection can be created in the Connections section of the configuration of a given project. In the Add Connection dropdown, select the Gradle Enterprise connection type.
+A Develocity connection can be created in the Connections section of the configuration of a given project. In the Add Connection dropdown, select the Develocity connection type.
 
-Fill out the Add Connection dialog with the URL for the Gradle Enterprise instance, the plugin and extension versions to be applied, and any other fields as needed. Some values, such as the plugin and extension versions, will be pre-populated.
+Fill out the Add Connection dialog with the URL for the Develocity instance, the plugin and extension versions to be applied, and any other fields as needed. Some values, such as the plugin and extension versions, will be pre-populated.
 
-A Gradle Enterprise connection can be created on any project and is automatically inherited by all its child projects.
+A Develocity connection can be created on any project and is automatically inherited by all its child projects.
 
 <details>
 
@@ -95,18 +95,18 @@ The TeamCity configuration parameters can be set on any project and are automati
 
 #### Gradle Builds
 
-1. In TeamCity, on the build configuration for which you want to apply Gradle Enterprise, create three configuration parameters:
+1. In TeamCity, on the build configuration for which you want to apply Develocity, create three configuration parameters:
 
-   - `buildScanPlugin.gradle-enterprise.url` - the URL of the Gradle Enterprise instance to which to publish build scans
-   - `buildScanPlugin.gradle-enterprise.plugin.version` - the version of the [Gradle Enterprise Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) to apply
+   - `buildScanPlugin.gradle-enterprise.url` - the URL of the Develocity instance to which to publish build scans
+   - `buildScanPlugin.gradle-enterprise.plugin.version` - the version of the [Develocity Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) to apply
    - `buildScanPlugin.ccud.plugin.version` - the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply (optional)
 
 2. If required, provide additional configuration parameters for your environment (optional):
 
-    - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Gradle Enterprise instance is using a self-signed certificate
-    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Gradle Enterprise URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Gradle Enterprise URL
+    - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate
+    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Develocity URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Develocity URL
     - `buildScanPlugin.gradle.plugin-repository.url` - the URL of the repository to use when resolving the GE and CCUD plugins; required if your TeamCity agents are not able to access the Gradle Plugin Portal
-    - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for _Command Line_ build steps; by default only steps using the _Gradle_ runner are enabled
+    - `buildScanPlugin.command-line-build-step.enabled` - enable Develocity integration for _Command Line_ build steps; by default only steps using the _Gradle_ runner are enabled
 
 ##### Example Gradle Configuration
 
@@ -114,19 +114,19 @@ The TeamCity configuration parameters can be set on any project and are automati
 
 #### Maven Builds
 
-1. In TeamCity, on the build configuration for which you want to integrate Gradle Enterprise, create three configuration parameters:
+1. In TeamCity, on the build configuration for which you want to integrate Develocity, create three configuration parameters:
 
-   - `buildScanPlugin.gradle-enterprise.url` - the URL of the Gradle Enterprise instance to which to publish build scans
-   - `buildScanPlugin.gradle-enterprise.extension.version` - the version of the [Gradle Enterprise Maven extension](https://docs.gradle.com/enterprise/maven-extension/) to apply
+   - `buildScanPlugin.gradle-enterprise.url` - the URL of the Develocity instance to which to publish build scans
+   - `buildScanPlugin.gradle-enterprise.extension.version` - the version of the [Develocity Maven extension](https://docs.gradle.com/enterprise/maven-extension/) to apply
    - `buildScanPlugin.ccud.extension.version` - the version of the [Common Custom User Data Maven extension](https://github.com/gradle/common-custom-user-data-maven-extension) to apply (optional)
 
 2. If required, provide additional configuration parameters for your environment (optional):
 
-    - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Gradle Enterprise instance is using a self-signed certificate
-    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Gradle Enterprise URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Gradle Enterprise URL
-    - `buildScanPlugin.gradle-enterprise.extension.custom.coordinates` - the coordinates of a custom extension that has a transitive dependency on the Gradle Enterprise Maven Extension
+    - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate
+    - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Develocity URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Develocity URL
+    - `buildScanPlugin.gradle-enterprise.extension.custom.coordinates` - the coordinates of a custom extension that has a transitive dependency on the Develocity Maven Extension
     - `buildScanPlugin.ccud.extension.custom.coordinates` - the coordinates of a custom Common Custom User Data Maven Extension or of a custom extension that has a transitive dependency on it
-    - `buildScanPlugin.command-line-build-step.enabled` - enable Gradle Enterprise integration for _Command Line_ build steps; by default only steps using the _Maven_ runner are enabled
+    - `buildScanPlugin.command-line-build-step.enabled` - enable Develocity integration for _Command Line_ build steps; by default only steps using the _Maven_ runner are enabled
 
 ##### Example Maven Configuration
 
@@ -148,26 +148,26 @@ The TeamCity configuration parameters can be set on any project and are automati
 
 ## Build Scan links surfacing
 
-The version of the Gradle Enterprise Gradle plugin and the Gradle Enterprise Maven extension that are applied to a build must meet a minimum version requirement for the link surfacing to work.
+The version of the Develocity Gradle plugin and the Develocity Maven extension that are applied to a build must meet a minimum version requirement for the link surfacing to work.
 
 | TC Build Scan plugin version | Minimum supported GE Maven extension version | Minimum supported GE Gradle plugin version |
 |------------------------------|----------------------------------------------|--------------------------------------------|
 | 0.23+                        | 1.11                                         | 3.0  (or Gradle Build Scan plugin 1.8)     |
 | 0.22                         | 1.0                                          | 3.0  (or Gradle Build Scan plugin 1.8)     |
 
-## Gradle Enterprise connectivity
+## Develocity connectivity
 
-The configured version of the Gradle Enterprise Gradle plugin and the Gradle Enterprise Maven extension that get automatically applied by the TeamCity Build Scan plugin must be compatbile with the version of the Gradle Enterprise server that the build is connecting to.
+The configured version of the Develocity Gradle plugin and the Develocity Maven extension that get automatically applied by the TeamCity Build Scan plugin must be compatible with the version of the Develocity server that the build is connecting to.
 
 ### Gradle builds
 
-The compatibility of the specified version of the Gradle Enterprise Gradle plugin with Gradle Enterprise can be found [here](https://docs.gradle.com/enterprise/compatibility/#gradle_enterprise_gradle_plugin). The compatibility of the optionally specified version of the Common Custom User Data Gradle plugin with the Gradle Enterprise Gradle plugin can be found [here](https://github.com/gradle/common-custom-user-data-gradle-plugin#version-compatibility).
+The compatibility of the specified version of the Develocity Gradle plugin with Develocity can be found [here](https://docs.gradle.com/enterprise/compatibility/#gradle_enterprise_gradle_plugin). The compatibility of the optionally specified version of the Common Custom User Data Gradle plugin with the Develocity Gradle plugin can be found [here](https://github.com/gradle/common-custom-user-data-gradle-plugin#version-compatibility).
 
 ### Maven builds
 
-The compatibility of the specified version of the Gradle Enterprise Maven extension with Gradle Enterprise can be found [here](https://docs.gradle.com/enterprise/compatibility/#gradle_enterprise_compatibility_2). The compatibility of the optionally specified version of the Common Custom User Data Maven extension with the Gradle Enterprise Maven extension can be found [here](https://github.com/gradle/common-custom-user-data-maven-extension#version-compatibility).
+The compatibility of the specified version of the Develocity Maven extension with Develocity can be found [here](https://docs.gradle.com/enterprise/compatibility/#gradle_enterprise_compatibility_2). The compatibility of the optionally specified version of the Common Custom User Data Maven extension with the Develocity Maven extension can be found [here](https://github.com/gradle/common-custom-user-data-maven-extension#version-compatibility).
 
-For Maven builds, the version of the Gradle Enterprise Maven extension automatically applied by the TeamCity Build Scan plugin is currently bundled by the plugin and cannot be configured. This will change in a future version of this plugin.
+For Maven builds, the version of the Develocity Maven extension automatically applied by the TeamCity Build Scan plugin is currently bundled by the plugin and cannot be configured. This will change in a future version of this plugin.
 
 <details>
 
@@ -193,17 +193,17 @@ For Maven builds, the version of the Gradle Enterprise Maven extension automatic
 Both feedback and contributions are very welcome.
 
 # Acknowledgements
-+ [bigdaz](https://github.com/bigdaz) (several prs related to the Gradle Enterprise integration)
-+ [clayburn](https://github.com/clayburn) (several prs related to the Gradle Enterprise integration)
-+ [marcphilipp](https://github.com/marcphilipp) (pr #53 that adds Gradle 4/5 compatibility to the Gradle Enterprise integration)
-+ [ldaley](https://github.com/ldaley) (pr #53 that adds Gradle 4/5 compatibility to the Gradle Enterprise integration)
++ [bigdaz](https://github.com/bigdaz) (several prs related to the Develocity integration)
++ [clayburn](https://github.com/clayburn) (several prs related to the Develocity integration)
++ [marcphilipp](https://github.com/marcphilipp) (pr #53 that adds Gradle 4/5 compatibility to the Develocity integration)
++ [ldaley](https://github.com/ldaley) (pr #53 that adds Gradle 4/5 compatibility to the Develocity integration)
 + [madlexa](https://github.com/madlexa) (pr #47 that adds TeamCity 2022.04 compatibility)
 + [facewindu](https://github.com/facewindu) (pr #21 that includes init script test coverage)
 + [dmitry-treskunov](https://github.com/dmitry-treskunov) (bug report and proposed fix)
 + [pbielicki](https://github.com/pbielicki) (pr #17 that adds a hint to the BuildScanServiceMessageMavenExtension @Component)
 + [jonnybbb](https://github.com/jonnybbb) (pr #14 and #15 that store build scan links under artifacts and clean up legacy data)
 + [davidburstromspotify](https://github.com/davidburstromspotify) (bug report and proposed fix)
-+ [guylabs](https://github.com/guylabs) (pr #10 that provides support for the Gradle Enterprise Gradle plugin)
++ [guylabs](https://github.com/guylabs) (pr #10 that provides support for the Develocity Gradle plugin)
 + [autonomousapps](https://github.com/autonomousapps) (pr #9 that provides build scans for Maven builds)
 + [mark-vieira](https://github.com/mark-vieira) (pr #6 that provides message service functionality)
 + [pavelsher](https://github.com/pavelsher) (several code pointers)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The TeamCity configuration parameters can be set on any project and are automati
 
     - `buildScanPlugin.gradle-enterprise.allow-untrusted-server` - allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate
     - `buildScanPlugin.gradle-enterprise.enforce-url` - enforce the configured Develocity URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Develocity URL
-    - `buildScanPlugin.gradle.plugin-repository.url` - the URL of the repository to use when resolving the GE and CCUD plugins; required if your TeamCity agents are not able to access the Gradle Plugin Portal
+    - `buildScanPlugin.gradle.plugin-repository.url` - the URL of the repository to use when resolving the Develocity and CCUD plugins; required if your TeamCity agents are not able to access the Gradle Plugin Portal
     - `buildScanPlugin.command-line-build-step.enabled` - enable Develocity integration for _Command Line_ build steps; by default only steps using the _Gradle_ runner are enabled
 
 ##### Example Gradle Configuration
@@ -150,10 +150,10 @@ The TeamCity configuration parameters can be set on any project and are automati
 
 The version of the Develocity Gradle plugin and the Develocity Maven extension that are applied to a build must meet a minimum version requirement for the link surfacing to work.
 
-| TC Build Scan plugin version | Minimum supported GE Maven extension version | Minimum supported GE Gradle plugin version |
-|------------------------------|----------------------------------------------|--------------------------------------------|
-| 0.23+                        | 1.11                                         | 3.0  (or Gradle Build Scan plugin 1.8)     |
-| 0.22                         | 1.0                                          | 3.0  (or Gradle Build Scan plugin 1.8)     |
+| TC Build Scan plugin version | Minimum supported Develocity Maven extension version | Minimum supported Develocity Gradle plugin version |
+|------------------------------|------------------------------------------------------|----------------------------------------------------|
+| 0.23+                        | 1.11                                                 | 3.0  (or Gradle Build Scan plugin 1.8)             |
+| 0.22                         | 1.0                                                  | 3.0  (or Gradle Build Scan plugin 1.8)             |
 
 ## Develocity connectivity
 
@@ -173,18 +173,18 @@ For Maven builds, the version of the Develocity Maven extension automatically ap
 
 <summary>Click for an overview of what Maven extension versions are bundled and injected.</summary>
 
-| TC Build Scan plugin version | Injected GE Maven extension version | Injected Common CCUD Maven extension version |
-|------------------------------|-------------------------------------|----------------------------------------------|
-| Next                         | 1.20                                | 1.12.5                                       |
-| 0.35                         | 1.18.1                              | 1.12.2                                       |
-| 0.34                         | 1.18                                | 1.12.2                                       |
-| 0.33                         | 1.16.1                              | 1.11.1                                       |
-| 0.32                         | 1.15.4                              | 1.11.1                                       |
-| 0.31                         | 1.15.3                              | 1.11.1                                       |
-| 0.30                         | 1.15.1                              | 1.11                                         |
-| 0.27 - 0.29                  | 1.14.3                              | 1.10.1                                       |
-| 0.25 - 0.26                  | 1.14.2                              | 1.10.1                                       |
-| 0.23 - 0.24                  | 1.14.1                              | 1.10.1                                       |
+| TC Build Scan plugin version | Injected Develocity Maven extension version | Injected Common CCUD Maven extension version |
+|------------------------------|---------------------------------------------|----------------------------------------------|
+| Next                         | 1.20                                        | 1.12.5                                       |
+| 0.35                         | 1.18.1                                      | 1.12.2                                       |
+| 0.34                         | 1.18                                        | 1.12.2                                       |
+| 0.33                         | 1.16.1                                      | 1.11.1                                       |
+| 0.32                         | 1.15.4                                      | 1.11.1                                       |
+| 0.31                         | 1.15.3                                      | 1.11.1                                       |
+| 0.30                         | 1.15.1                                      | 1.11                                         |
+| 0.27 - 0.29                  | 1.14.3                                      | 1.10.1                                       |
+| 0.25 - 0.26                  | 1.14.2                                      | 1.10.1                                       |
+| 0.23 - 0.24                  | 1.14.1                                      | 1.10.1                                       |
 
 </details>
 

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -53,7 +53,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
 
     private static final String GRADLE_BUILDSCAN_TEAMCITY_PLUGIN = "GRADLE_BUILDSCAN_TEAMCITY_PLUGIN";
 
-    // TeamCity GE configuration parameters
+    // TeamCity Develocity configuration parameters
 
     private static final String GRADLE_PLUGIN_REPOSITORY_CONFIG_PARAM = "buildScanPlugin.gradle.plugin-repository.url";
     private static final String GE_URL_CONFIG_PARAM = "buildScanPlugin.gradle-enterprise.url";

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * This class is responsible for injecting a Gradle init script into all Gradle build runners. This init script itself registers a callback on the build scan plugin for any
  * published build scans and emits a TeamCity {@link jetbrains.buildServer.messages.serviceMessages.ServiceMessage} containing the scan URL.
  * <p>
- * In the presence of certain configuration parameters, this class will also inject Gradle Enterprise and Common Custom User Data plugins and extensions into Gradle and Maven
+ * In the presence of certain configuration parameters, this class will also inject Develocity and Common Custom User Data plugins and extensions into Gradle and Maven
  * builds.
  */
 @SuppressWarnings({"SameParameterValue", "ResultOfMethodCallIgnored"})
@@ -102,14 +102,14 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     @Override
     public void beforeRunnerStart(@NotNull BuildRunnerContext runner) {
         if (runner.getRunType().equalsIgnoreCase(GRADLE_RUNNER)) {
-            LOG.info("Attempt to instrument Gradle build with Gradle Enterprise");
+            LOG.info("Attempt to instrument Gradle build with Develocity");
             instrumentGradleRunner(runner);
         } else if (runner.getRunType().equalsIgnoreCase(MAVEN_RUNNER)) {
-            LOG.info("Attempt to instrument Maven build with Gradle Enterprise");
+            LOG.info("Attempt to instrument Maven build with Develocity");
             instrumentMavenRunner(runner);
         } else if (runner.getRunType().equalsIgnoreCase(COMMAND_LINE_RUNNER)) {
             if (getBooleanConfigParam(INSTRUMENT_COMMAND_LINE_RUNNER_CONFIG_PARAM, runner)) {
-                LOG.info("Attempt to instrument command line build with Gradle Enterprise");
+                LOG.info("Attempt to instrument command line build with Develocity");
                 instrumentCommandLineRunner(runner);
             }
         }
@@ -218,7 +218,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
         // add extension to capture build scan URL
         extensionJars.add(getExtensionJar(BUILD_SCAN_EXT_MAVEN, runner));
 
-        // optionally add extensions that connect the Maven build with Gradle Enterprise
+        // optionally add extensions that connect the Maven build with Develocity
         MavenExtensions extensions = getMavenExtensions(runner);
         String geExtensionVersion = getOptionalConfigParam(GE_EXTENSION_VERSION_CONFIG_PARAM, runner);
         if (geExtensionVersion != null) {

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -29,7 +29,7 @@ initscript {
 
     if (gePluginVersion || ccudPluginVersion && atLeastGradle4) {
         pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
-        logger.quiet("Gradle Enterprise plugins resolution: $pluginRepositoryUrl")
+        logger.quiet("Develocity plugins resolution: $pluginRepositoryUrl")
 
         repositories {
             maven { url pluginRepositoryUrl }
@@ -119,7 +119,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
                 if (!scanPluginComponent) {
                     logger.quiet("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
-                    logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+                    logger.quiet("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                     applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
@@ -131,7 +131,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (geUrl && geEnforceUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.quiet("Enforcing Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+                            logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
                         }
@@ -160,7 +160,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         if (gePluginVersion) {
             if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
                 logger.quiet("Applying $GRADLE_ENTERPRISE_PLUGIN_CLASS via init script")
-                logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+                logger.quiet("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                 applyPluginExternally(settings.pluginManager, GRADLE_ENTERPRISE_PLUGIN_CLASS)
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
                     ext.server = geUrl
@@ -173,7 +173,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
             if (geUrl && geEnforceUrl) {
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
-                    logger.quiet("Enforcing Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+                    logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                 }

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/gradle/GEPluginApplicationInitScriptTest.groovy
@@ -358,19 +358,19 @@ class GEPluginApplicationInitScriptTest extends BaseInitScriptTest {
     }
 
     void outputContainsGeConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer) {
-        def geConnectionInfo = "Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer"
+        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer"
         assert result.output.contains(geConnectionInfo)
         assert 1 == result.output.count(geConnectionInfo)
     }
 
     void outputContainsPluginRepositoryInfo(BuildResult result, String gradlePluginRepositoryUrl) {
-        def repositoryInfo = "Gradle Enterprise plugins resolution: ${gradlePluginRepositoryUrl}"
+        def repositoryInfo = "Develocity plugins resolution: ${gradlePluginRepositoryUrl}"
         assert result.output.contains(repositoryInfo)
         assert 1 == result.output.count(repositoryInfo)
     }
 
     void outputEnforcesGeUrl(BuildResult result, String geUrl, boolean geAllowUntrustedServer) {
-        def enforceUrl = "Enforcing Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer"
+        def enforceUrl = "Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer"
         assert result.output.contains(enforceUrl)
         assert 1 == result.output.count(enforceUrl)
     }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- Informs the Gradle Enterprise Gradle plugin that it is being applied externally.
+- Informs the Develocity Gradle plugin that it is being applied externally.

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -3,7 +3,7 @@ package nu.studer.teamcity.buildscan.connection;
 @SuppressWarnings("unused")
 public final class GradleEnterpriseConnectionConstants {
 
-    // Constants defined by the Gradle Enterprise Connection
+    // Constants defined by the Develocity Connection
     // These are used to correlate data set by the user in the connection dialog to the descriptor parameters available in the Project Feature Descriptor Parameters
 
     public static final String GRADLE_PLUGIN_REPOSITORY_URL = "gradlePluginRepositoryUrl";

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionConstants.java
@@ -37,7 +37,7 @@ public final class GradleEnterpriseConnectionConstants {
 
     public static final String GRADLE_ENTERPRISE_CONNECTION_PROVIDER = "gradle-enterprise-connection-provider";
 
-    // The below getters exist so that geConnectionDialog.jsp can read these constants using JavaBean conventions
+    // The below getters exist so that develocityConnectionDialog.jsp can read these constants using JavaBean conventions
 
     public String getGradlePluginRepositoryUrl() {
         return GRADLE_PLUGIN_REPOSITORY_URL;

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -52,7 +52,7 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
     @NotNull
     @Override
     public String getDisplayName() {
-        return "Gradle Enterprise";
+        return "Develocity";
     }
 
     @Nullable
@@ -66,11 +66,11 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
     public String describeConnection(@NotNull OAuthConnectionDescriptor connection) {
         Map<String, String> params = connection.getParameters();
 
-        String description = "Gradle Enterprise Connection Settings:\n";
+        String description = "Develocity Connection Settings:\n";
 
         String geUrl = params.get(GRADLE_ENTERPRISE_URL);
         if (geUrl != null) {
-            description += String.format("* Gradle Enterprise Server URL: %s\n", geUrl);
+            description += String.format("* Develocity Server URL: %s\n", geUrl);
         }
 
         String allowUntrustedServer = params.get(ALLOW_UNTRUSTED_SERVER);
@@ -80,19 +80,19 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
 
         String geAccessKey = params.get(GRADLE_ENTERPRISE_ACCESS_KEY);
         if (geAccessKey != null) {
-            description += String.format("* Gradle Enterprise Access Key: %s\n", "******");
+            description += String.format("* Develocity Access Key: %s\n", "******");
         }
 
         String enforceGeUrl = params.get(ENFORCE_GRADLE_ENTERPRISE_URL);
         if (enforceGeUrl != null) {
-            description += String.format("* Enforce Gradle Enterprise Server URL: %s\n", enforceGeUrl);
+            description += String.format("* Enforce Develocity Server URL: %s\n", enforceGeUrl);
         }
 
         description += "\nGradle Settings:\n";
 
         String gePluginVersion = params.get(GE_PLUGIN_VERSION);
         if (gePluginVersion != null) {
-            description += String.format("* Gradle Enterprise Gradle Plugin Version: %s\n", gePluginVersion);
+            description += String.format("* Develocity Gradle Plugin Version: %s\n", gePluginVersion);
         }
 
         String ccudPluginVersion = params.get(CCUD_PLUGIN_VERSION);
@@ -109,7 +109,7 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
 
         String geExtensionVersion = params.get(GE_EXTENSION_VERSION);
         if (geExtensionVersion != null) {
-            description += String.format("* Gradle Enterprise Maven Extension Version: %s\n", geExtensionVersion);
+            description += String.format("* Develocity Maven Extension Version: %s\n", geExtensionVersion);
         }
 
         String ccudExtensionVersion = params.get(CCUD_EXTENSION_VERSION);
@@ -119,7 +119,7 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
 
         String customGeExtensionCoordinates = params.get(CUSTOM_GE_EXTENSION_COORDINATES);
         if (customGeExtensionCoordinates != null) {
-            description += String.format("* Gradle Enterprise Maven Extension Custom Coordinates: %s\n", customGeExtensionCoordinates);
+            description += String.format("* Develocity Maven Extension Custom Coordinates: %s\n", customGeExtensionCoordinates);
         }
 
         String customCcudExtensionCoordinates = params.get(CUSTOM_CCUD_EXTENSION_COORDINATES);

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProvider.java
@@ -58,7 +58,7 @@ public final class GradleEnterpriseConnectionProvider extends OAuthProvider {
     @Nullable
     @Override
     public String getEditParametersUrl() {
-        return descriptor.getPluginResourcesPath("geConnectionDialog.jsp");
+        return descriptor.getPluginResourcesPath("develocityConnectionDialog.jsp");
     }
 
     @NotNull

--- a/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/connection/GradleEnterpriseParametersProvider.java
@@ -42,7 +42,7 @@ import static nu.studer.teamcity.buildscan.connection.GradleEnterpriseConnection
 
 /**
  * This implementation of {@link BuildParametersProvider} injects configuration parameters and environment variables
- * needed in order to automatically apply Gradle Enterprise to Gradle and Maven builds, based on the configuration of
+ * needed in order to automatically apply Develocity to Gradle and Maven builds, based on the configuration of
  * the connection.
  */
 @SuppressWarnings({"DuplicatedCode", "Convert2Diamond"})

--- a/src/main/java/nu/studer/teamcity/buildscan/internal/slack/SlackPayloadFactory.java
+++ b/src/main/java/nu/studer/teamcity/buildscan/internal/slack/SlackPayloadFactory.java
@@ -34,7 +34,7 @@ final class SlackPayloadFactory {
         String buildUrl = String.format("%s/viewLog.html?buildId=%s", serverUrl, buildId);
 
         // hard-code username
-        payload.username("Gradle Enterprise");
+        payload.username("Develocity");
 
         // main text
         String tcBuildOutcome =

--- a/src/main/resources/buildServerResources/develocityConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/develocityConnectionDialog.jsp
@@ -80,7 +80,7 @@
     <td><label for="${keys.gradlePluginRepositoryUrl}">Gradle Plugin Repository URL:</label></td>
     <td>
         <props:textProperty name="${keys.gradlePluginRepositoryUrl}" className="longField"/>
-        <span class="smallNote">The URL of the repository to use when resolving the GE and CCUD plugins. Defaults to the Gradle Plugin Portal.</span>
+        <span class="smallNote">The URL of the repository to use when resolving the Develocity and CCUD plugins. Defaults to the Gradle Plugin Portal.</span>
 
     </td>
 </tr>

--- a/src/main/resources/buildServerResources/develocityConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/develocityConnectionDialog.jsp
@@ -14,14 +14,14 @@
 </tr>
 
 <tr class="groupingTitle">
-    <td colspan="2">Gradle Enterprise Connection Settings</td>
+    <td colspan="2">Develocity Connection Settings</td>
 </tr>
 
 <tr>
-    <td><label for="${keys.gradleEnterpriseUrl}">Gradle Enterprise Server URL:</label></td>
+    <td><label for="${keys.gradleEnterpriseUrl}">Develocity Server URL:</label></td>
     <td>
         <props:textProperty name="${keys.gradleEnterpriseUrl}" className="longField"/>
-        <span class="smallNote">The URL of the Gradle Enterprise server.</span>
+        <span class="smallNote">The URL of the Develocity server.</span>
     </td>
 </tr>
 
@@ -34,19 +34,19 @@
 </tr>
 
 <tr>
-    <td><label for="${keys.gradleEnterpriseAccessKey}">Gradle Enterprise Access Key:</label></td>
+    <td><label for="${keys.gradleEnterpriseAccessKey}">Develocity Access Key:</label></td>
     <td>
         <props:passwordProperty name="${keys.gradleEnterpriseAccessKey}" className="longField"/>
         <span class="error" id="error_${keys.gradleEnterpriseAccessKey}"></span>
-        <span class="smallNote">The access key for authenticating with the Gradle Enterprise server.</span>
+        <span class="smallNote">The access key for authenticating with the Develocity server.</span>
     </td>
 </tr>
 
 <tr>
-    <td><label for="${keys.enforceGradleEnterpriseUrl}">Enforce Gradle Enterprise Server URL:</label></td>
+    <td><label for="${keys.enforceGradleEnterpriseUrl}">Enforce Develocity Server URL:</label></td>
     <td>
         <props:checkboxProperty name="${keys.enforceGradleEnterpriseUrl}"/>
-        <span class="smallNote">Whether to enforce the Gradle Enterprise Server URL configured in this connection over a URL configured in the project's build.</span>
+        <span class="smallNote">Whether to enforce the Develocity Server URL configured in this connection over a URL configured in the project's build.</span>
     </td>
 </tr>
 
@@ -61,10 +61,10 @@
 </tr>
 
 <tr>
-    <td><label for="${keys.gradleEnterprisePluginVersion}">Gradle Enterprise Gradle Plugin Version:</label></td>
+    <td><label for="${keys.gradleEnterprisePluginVersion}">Develocity Gradle Plugin Version:</label></td>
     <td>
         <props:textProperty name="${keys.gradleEnterprisePluginVersion}" className="longField"/>
-        <span class="smallNote">The version of the Gradle Enterprise Gradle Plugin to apply to Gradle builds.</span>
+        <span class="smallNote">The version of the Develocity Gradle Plugin to apply to Gradle builds.</span>
     </td>
 </tr>
 
@@ -90,10 +90,10 @@
 </tr>
 
 <tr>
-    <td><label for="${keys.gradleEnterpriseExtensionVersion}">Gradle Enterprise Maven Extension Version:</label></td>
+    <td><label for="${keys.gradleEnterpriseExtensionVersion}">Develocity Maven Extension Version:</label></td>
     <td>
         <props:textProperty name="${keys.gradleEnterpriseExtensionVersion}" className="longField"/>
-        <span class="smallNote">The version of the Gradle Enterprise Maven Extension to apply to Maven builds.</span>
+        <span class="smallNote">The version of the Develocity Maven Extension to apply to Maven builds.</span>
     </td>
 </tr>
 
@@ -106,10 +106,10 @@
 </tr>
 
 <tr class="advancedSetting">
-    <td><label for="${keys.customGradleEnterpriseExtensionCoordinates}">Gradle Enterprise Maven Extension Custom Coordinates:</label></td>
+    <td><label for="${keys.customGradleEnterpriseExtensionCoordinates}">Develocity Maven Extension Custom Coordinates:</label></td>
     <td>
         <props:textProperty name="${keys.customGradleEnterpriseExtensionCoordinates}" className="longField"/>
-        <span class="smallNote">The coordinates of a custom extension that has a transitive dependency on the Gradle Enterprise Maven Extension.</span>
+        <span class="smallNote">The coordinates of a custom extension that has a transitive dependency on the Develocity Maven Extension.</span>
     </td>
 </tr>
 

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/GradleEnterpriseConnectionProviderTest.groovy
@@ -57,13 +57,13 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         where:
         parameter                          | value                           | text
         GRADLE_PLUGIN_REPOSITORY_URL       | 'https://plugins.example.com'   | 'Gradle Plugin Repository URL'
-        GRADLE_ENTERPRISE_URL              | 'https://ge.example.com'        | 'Gradle Enterprise Server URL'
+        GRADLE_ENTERPRISE_URL              | 'https://ge.example.com'        | 'Develocity Server URL'
         ALLOW_UNTRUSTED_SERVER             | 'true'                          | 'Allow Untrusted Server'
-        GE_PLUGIN_VERSION                  | '3.16.1'                        | 'Gradle Enterprise Gradle Plugin Version'
+        GE_PLUGIN_VERSION                  | '3.16.1'                        | 'Develocity Gradle Plugin Version'
         CCUD_PLUGIN_VERSION                | '1.12.1'                        | 'Common Custom User Data Gradle Plugin Version'
-        GE_EXTENSION_VERSION               | '1.20'                          | 'Gradle Enterprise Maven Extension Version'
+        GE_EXTENSION_VERSION               | '1.20'                          | 'Develocity Maven Extension Version'
         CCUD_EXTENSION_VERSION             | '1.12.5'                        | 'Common Custom User Data Maven Extension Version'
-        CUSTOM_GE_EXTENSION_COORDINATES    | 'com.company:my-ge-extension'   | 'Gradle Enterprise Maven Extension Custom Coordinates'
+        CUSTOM_GE_EXTENSION_COORDINATES    | 'com.company:my-ge-extension'   | 'Develocity Maven Extension Custom Coordinates'
         CUSTOM_CCUD_EXTENSION_COORDINATES  | 'com.company:my-ccud-extension' | 'Common Custom User Data Maven Extension Custom Coordinates'
         INSTRUMENT_COMMAND_LINE_BUILD_STEP | 'true'                          | 'Instrument Command Line Build Steps'
     }
@@ -77,7 +77,7 @@ class GradleEnterpriseConnectionProviderTest extends Specification {
         def description = connectionProvider.describeConnection(connection)
 
         then:
-        description.contains('Gradle Enterprise Access Key: ******')
+        description.contains('Develocity Access Key: ******')
     }
 
     def "returns validation error if access key is invalid"() {

--- a/src/test/groovy/nu/studer/teamcity/buildscan/internal/slack/SlackPayloadFactoryTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/internal/slack/SlackPayloadFactoryTest.groovy
@@ -25,7 +25,7 @@ class SlackPayloadFactoryTest extends Specification {
 
         then:
         json == """{
-  "username": "Gradle Enterprise",
+  "username": "Develocity",
   "text": "TeamCity <http://tc.server.org/viewLog.html?buildId=23|[My Configuration]> succeeded. 1 build scan published:",
   "attachments": [
     {
@@ -59,7 +59,7 @@ class SlackPayloadFactoryTest extends Specification {
 
         then:
         json == """{
-  "username": "Gradle Enterprise",
+  "username": "Develocity",
   "text": "TeamCity <http://tc.server.org/viewLog.html?buildId=23|[My Configuration]> failed. 2 build scans published:",
   "attachments": [
     {


### PR DESCRIPTION
## Summary

Update user-facing product references to "Develocity" instead of "Gradle Enterprise". All code references (e.g., variable names) will be updated as we change the injection logic.