### PR TITLE
Generate build-scan-init.gradle from the reference init-script

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -28,8 +28,22 @@ dependencies {
     testImplementation('org.spockframework:spock-junit4:2.3-groovy-3.0')
 }
 
+def generateInitScript = tasks.register('generateInitScript') {
+    def referenceInitScript = file('src/main/resources/init-scripts/develocity-injection.init.gradle')
+    def buildScanCollector = file('src/main/resources/init-scripts/build-scan-collector.groovy')
+    def generatedInitScript = project.layout.buildDirectory.file('generated-resources/build-scan-init.gradle')
+    inputs.file(referenceInitScript)
+    inputs.file(buildScanCollector)
+    outputs.file(generatedInitScript)
+    doLast {
+        generatedInitScript.get().asFile.text =
+            referenceInitScript.text.replace("class BuildScanCollector {}", buildScanCollector.text)
+    }
+}
+
 processResources {
     from configurations.mvnExtensions
+    from generateInitScript
 }
 
 java {

--- a/agent/src/main/resources/build-scan-init.gradle
+++ b/agent/src/main/resources/build-scan-init.gradle
@@ -1,6 +1,9 @@
-import org.gradle.util.GradleVersion
+/*
+ * Initscript for injection of Develocity into Gradle builds.
+ * Version: v0.5.0-unpublished
+ */
 
-import java.util.concurrent.atomic.AtomicBoolean
+import org.gradle.util.GradleVersion
 
 // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
 
@@ -12,7 +15,8 @@ initscript {
     }
 
     def getInputParam = { String name ->
-        def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+        def ENV_VAR_PREFIX = ''
+        def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
         return System.getProperty(name) ?: System.getenv(envVarName)
     }
 
@@ -22,9 +26,9 @@ initscript {
         return
     }
 
-    // finish early if injection is disabled
-    def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-    if (gradleInjectionEnabled != "true") {
+    // plugin loading is only required for Develocity injection
+    def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+    if (!develocityInjectionEnabled) {
         return
     }
 
@@ -77,31 +81,15 @@ initscript {
     }
 }
 
-def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
-def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
-
-def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
-def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
-def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
-
-def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
-def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
-def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
-
-def SETTINGS_EXTENSION_CLASSES = [GRADLE_ENTERPRISE_EXTENSION_CLASS, DEVELOCITY_CONFIGURATION_CLASS]
-
-def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
-def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
-def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+static getInputParam(String name) {
+    def ENV_VAR_PREFIX = ''
+    def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
+    return System.getProperty(name) ?: System.getenv(envVarName)
+}
 
 def isTopLevelBuild = !gradle.parent
 if (!isTopLevelBuild) {
     return
-}
-
-def getInputParam = { String name ->
-    def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
 }
 
 def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
@@ -111,249 +99,227 @@ if (requestedInitScriptName != initScriptName) {
     return
 }
 
-// finish early if injection is disabled
-def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-if (gradleInjectionEnabled != "true") {
-    return
+def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+if (develocityInjectionEnabled) {
+    enableDevelocityInjection()
 }
 
-def develocityUrl = getInputParam('develocity.url')
-def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
-def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
-def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-def develocityCaptureFileFingerprints = Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints'))
-def develocityPluginVersion = getInputParam('develocity.plugin.version')
-def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
-def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
-def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
-def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
-
-def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
-def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
-def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
-
-def dvOrGe = { def dvValue, def geValue ->
-    if (shouldApplyDevelocityPlugin) {
-        return dvValue instanceof Closure<?> ? dvValue() : dvValue
-    }
-    return geValue instanceof Closure<?> ? geValue() : geValue
+// To enable build-scan capture, a `captureBuildScanLink(String)` method must be added to `BuildScanCollector`.
+def buildScanCollector = new BuildScanCollector()
+def buildScanCaptureEnabled = buildScanCollector.metaClass.respondsTo(buildScanCollector, 'captureBuildScanLink', String)
+if (buildScanCaptureEnabled) {
+    enableBuildScanLinkCapture(buildScanCollector)
 }
 
-// finish early if configuration parameters passed in via system properties are not valid/supported
-if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
-    logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
-    return
-}
+void enableDevelocityInjection() {
+    def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+    def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
-// log via helper class to be Configuration Cache compatible when logging is required from callback function
-def buildScanLifeCycleLogger = new BuildScanLifeCycleLogger(logger)
+    def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+    def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
 
-// send a message to the server that the build has started
-buildScanLifeCycleLogger.log('BUILD_STARTED')
+    def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+    def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
 
-// define a buildScanPublished listener that captures the build scan URL and sends it in a message to the server
-def actionRunMarker = new AtomicBoolean(false)
-def buildScanPublishedAction = { def buildScan ->
-    if (actionRunMarker.compareAndSet(false, true)) {
-        if (buildScan.metaClass.respondsTo(buildScan, 'buildScanPublished', Action)) {
-            buildScan.buildScanPublished { scan ->
-                buildScanLifeCycleLogger.log("BUILD_SCAN_URL:${scan.buildScanUri.toString()}")
-            }
+    def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
+    def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
+    def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+
+    def develocityUrl = getInputParam('develocity.url')
+    def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
+    def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
+    def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
+    def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
+    def develocityPluginVersion = getInputParam('develocity.plugin.version')
+    def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+    def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
+    def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
+    def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+
+    def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+    def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+    def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
+
+    def dvOrGe = { def dvValue, def geValue ->
+        if (shouldApplyDevelocityPlugin) {
+            return dvValue instanceof Closure<?> ? dvValue() : dvValue
         }
+        return geValue instanceof Closure<?> ? geValue() : geValue
     }
-}
 
-// register buildScanPublished listener and optionally apply the Develocity plugin
-if (GradleVersion.current() < GradleVersion.version('6.0')) {
-    rootProject {
-        buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
-            def resolutionResult = incoming.resolutionResult
+    // finish early if configuration parameters passed in via system properties are not valid/supported
+    if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
+        logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
+        return
+    }
 
-            if (develocityPluginVersion) {
-                def scanPluginComponent = resolutionResult.allComponents.find {
-                    it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
-                }
-                if (!scanPluginComponent) {
-                    def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
-                    logger.lifecycle("Applying $pluginClass via init script")
-                    applyPluginExternally(pluginManager, pluginClass)
-                    def rootExtension = dvOrGe(
+    // Conditionally apply and configure the Develocity plugin
+    if (GradleVersion.current() < GradleVersion.version('6.0')) {
+        rootProject {
+            buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
+                def resolutionResult = incoming.resolutionResult
+
+                if (develocityPluginVersion) {
+                    def scanPluginComponent = resolutionResult.allComponents.find {
+                        it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
+                    }
+                    if (!scanPluginComponent) {
+                        def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
+                        logger.lifecycle("Applying $pluginClass via init script")
+                        applyPluginExternally(pluginManager, pluginClass)
+                        def rootExtension = dvOrGe(
                             { develocity },
                             { buildScan }
-                    )
-                    def buildScanExtension = dvOrGe(
+                        )
+                        def buildScanExtension = dvOrGe(
                             { rootExtension.buildScan },
                             { rootExtension }
-                    )
-                    if (develocityUrl) {
-                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                        rootExtension.server = develocityUrl
-                        rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
-                    }
-                    if (!shouldApplyDevelocityPlugin) {
-                        // Develocity plugin publishes scans by default
-                        buildScanExtension.publishAlways()
-                    }
-                    // uploadInBackground not available for build-scan-plugin 1.16
-                    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
-                    buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                    if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
-                        if (isAtLeast(develocityPluginVersion, '3.17')) {
-                            buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
-                        } else if (isAtLeast(develocityPluginVersion, '3.7')) {
-                            buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
-                        } else {
-                            buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                        )
+                        if (develocityUrl) {
+                            logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            rootExtension.server = develocityUrl
+                            rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+                        if (!shouldApplyDevelocityPlugin) {
+                            // Develocity plugin publishes scans by default
+                            buildScanExtension.publishAlways()
+                        }
+                        // uploadInBackground not available for build-scan-plugin 1.16
+                        if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
+                        buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                        if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
+                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            if (isAtLeast(develocityPluginVersion, '3.17')) {
+                                buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
+                            } else if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
+                            } else {
+                                buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                            }
                         }
                     }
+
+                    if (develocityUrl && develocityEnforceUrl) {
+                        logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                    }
+
+                    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                        // Only execute if develocity plugin isn't applied.
+                        if (gradle.rootProject.extensions.findByName("develocity")) return
+                        afterEvaluate {
+                            if (develocityUrl && develocityEnforceUrl) {
+                                buildScan.server = develocityUrl
+                                buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                            }
+                        }
+
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                            buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                        }
+                    }
+
+                    pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                        afterEvaluate {
+                            if (develocityUrl && develocityEnforceUrl) {
+                                develocity.server = develocityUrl
+                                develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                            }
+                        }
+
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                            develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                        }
+                    }
+                }
+
+                if (ccudPluginVersion && atLeastGradle4) {
+                    def ccudPluginComponent = resolutionResult.allComponents.find {
+                        it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
+                    }
+                    if (!ccudPluginComponent) {
+                        logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                        pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+                    }
+                }
+            }
+        }
+    } else {
+        gradle.settingsEvaluated { settings ->
+            if (develocityPluginVersion) {
+                if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
+                    def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
+                    logger.lifecycle("Applying $pluginClass via init script")
+                    applyPluginExternally(settings.pluginManager, pluginClass)
+                    if (develocityUrl) {
+                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                        eachDevelocitySettingsExtension(settings) { ext ->
+                            ext.server = develocityUrl
+                            ext.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+                    }
+
+                    eachDevelocitySettingsExtension(settings) { ext ->
+                        ext.buildScan.uploadInBackground = buildScanUploadInBackground
+                        ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                    }
+
+                    eachDevelocitySettingsExtension(settings,
+                        { develocity ->
+                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                        },
+                        { gradleEnterprise ->
+                            gradleEnterprise.buildScan.publishAlways()
+                            if (isAtLeast(develocityPluginVersion, '2.1')) {
+                                logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                                if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                    gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
+                                } else {
+                                    gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
+                                }
+                            }
+                        }
+                    )
                 }
 
                 if (develocityUrl && develocityEnforceUrl) {
                     logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                 }
 
-                pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                    afterEvaluate {
-                        if (develocityUrl && develocityEnforceUrl) {
-                            buildScan.server = develocityUrl
-                            buildScan.allowUntrustedServer = develocityAllowUntrustedServer
-                        }
-                    }
-
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                        buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                    }
-
-                    if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
-                        if (isAtLeast(develocityPluginVersion, '3.7')) {
-                            buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
-                        } else {
-                            buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
-                        }
-                    }
-                }
-
-                pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                    afterEvaluate {
+                eachDevelocitySettingsExtension(settings,
+                    { develocity ->
                         if (develocityUrl && develocityEnforceUrl) {
                             develocity.server = develocityUrl
                             develocity.allowUntrustedServer = develocityAllowUntrustedServer
                         }
-                    }
 
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                    }
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                            develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                        }
+                    },
+                    { gradleEnterprise ->
+                        if (develocityUrl && develocityEnforceUrl) {
+                            gradleEnterprise.server = develocityUrl
+                            gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
 
-                    develocity.buildScan.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
-                }
-            }
-
-            if (ccudPluginVersion && atLeastGradle4) {
-                def ccudPluginComponent = resolutionResult.allComponents.find {
-                    it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
-                }
-                if (!ccudPluginComponent) {
-                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                    pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
-                }
-            }
-        }
-
-        pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-            buildScanPublishedAction(buildScan)
-        }
-
-        pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-            buildScanPublishedAction(buildScan)
-        }
-    }
-} else {
-    gradle.settingsEvaluated { settings ->
-        if (develocityPluginVersion) {
-            if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
-                def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
-                logger.lifecycle("Applying $pluginClass via init script")
-                applyPluginExternally(settings.pluginManager, pluginClass)
-                if (develocityUrl) {
-                    logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                    eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
-                        ext.server = develocityUrl
-                        ext.allowUntrustedServer = develocityAllowUntrustedServer
-                    }
-                }
-
-                eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
-                    ext.buildScan.uploadInBackground = buildScanUploadInBackground
-                    ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                }
-
-                eachDevelocitySettingsExtension(settings, [GRADLE_ENTERPRISE_EXTENSION_CLASS]) { ext ->
-                    ext.buildScan.publishAlways()
-                    if (isAtLeast(develocityPluginVersion, '2.1')) {
-                        if (isAtLeast(develocityPluginVersion, '3.7')) {
-                            ext.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
-                        } else {
-                            ext.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                            gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
                         }
                     }
-                }
-
-                eachDevelocitySettingsExtension(settings, [DEVELOCITY_CONFIGURATION_CLASS]) { ext ->
-                    ext.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
-                }
+                )
             }
 
-            if (develocityUrl && develocityEnforceUrl) {
-                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-            }
-
-            eachDevelocitySettingsExtension(settings, [GRADLE_ENTERPRISE_EXTENSION_CLASS]) { ext ->
-                if (develocityUrl && develocityEnforceUrl) {
-                    ext.server = develocityUrl
-                    ext.allowUntrustedServer = develocityAllowUntrustedServer
-                }
-
-                if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                    ext.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                    ext.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                }
-
-                if (isAtLeast(develocityPluginVersion, '2.1')) {
-                    if (isAtLeast(develocityPluginVersion, '3.7')) {
-                        ext.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
-                    } else {
-                        ext.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
-                    }
+            if (ccudPluginVersion) {
+                if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                    settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
                 }
             }
-
-            eachDevelocitySettingsExtension(settings, [DEVELOCITY_CONFIGURATION_CLASS]) { ext ->
-                if (develocityUrl && develocityEnforceUrl) {
-                    ext.server = develocityUrl
-                    ext.allowUntrustedServer = develocityAllowUntrustedServer
-                }
-
-                if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                    ext.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                    ext.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                }
-
-                ext.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
-            }
-        }
-
-        if (ccudPluginVersion) {
-            if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
-                logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
-            }
-        }
-
-        eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
-            buildScanPublishedAction(ext.buildScan)
         }
     }
 }
@@ -381,10 +347,26 @@ void applyPluginExternally(def pluginManager, String pluginClassName) {
     }
 }
 
-static def eachDevelocitySettingsExtension(def settings, List<String> publicTypes, def action) {
-    settings.extensions.extensionsSchema.elements.findAll { publicTypes.contains(it.publicType.concreteClass.name) }
+/**
+ * Apply the `dvAction` to all 'develocity' extensions.
+ * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
+ * (The develocity plugin creates both extensions, and we want to prefer configuring 'develocity').
+ */
+static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAction = dvAction) {
+    def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
+    def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
+
+    def dvExtensions = settings.extensions.extensionsSchema.elements
+        .findAll { it.publicType.concreteClass.name == DEVELOCITY_CONFIGURATION_CLASS }
+        .collect { settings[it.name] }
+    if (!dvExtensions.empty) {
+        dvExtensions.each(dvAction)
+    } else {
+        def geExtensions = settings.extensions.extensionsSchema.elements
+            .findAll { it.publicType.concreteClass.name == GRADLE_ENTERPRISE_EXTENSION_CLASS }
             .collect { settings[it.name] }
-            .each(action)
+        geExtensions.each(geAction)
+    }
 }
 
 static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
@@ -395,12 +377,51 @@ static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
     !isAtLeast(versionUnderTest, referenceVersion)
 }
 
-class BuildScanLifeCycleLogger {
+void enableBuildScanLinkCapture(BuildScanCollector collector) {
+    def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+    def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
 
-    def logger
+    // Conditionally apply and configure the Develocity plugin
+    if (GradleVersion.current() < GradleVersion.version('6.0')) {
+        rootProject {
+            pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                // Only execute if develocity plugin isn't applied.
+                if (gradle.rootProject.extensions.findByName("develocity")) return
+                buildScanPublishedAction(buildScan, collector)
+            }
 
-    BuildScanLifeCycleLogger(logger) {
-        this.logger = logger
+            pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                buildScanPublishedAction(develocity.buildScan, collector)
+            }
+        }
+    } else {
+        gradle.settingsEvaluated { settings ->
+            eachDevelocitySettingsExtension(settings) { ext ->
+                buildScanPublishedAction(ext.buildScan, collector)
+            }
+        }
+    }
+}
+
+// Action will only be called if a `BuildScanCollector.captureBuildScanLink` method is present.
+// Add `void captureBuildScanLink(String) {}` to the `BuildScanCollector` class to respond to buildScanPublished events
+static buildScanPublishedAction(def buildScanExtension, BuildScanCollector collector) {
+    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'buildScanPublished', Action)) {
+        buildScanExtension.buildScanPublished { scan ->
+            collector.captureBuildScanLink(scan.buildScanUri.toString())
+        }
+    }
+}
+
+// send a message to the server that the build has started
+buildScanCollector.logger = getLogger()
+buildScanCollector.log('BUILD_STARTED')
+
+class BuildScanCollector {
+    Logger logger
+
+    void captureBuildScanLink(String link) {
+        log("BUILD_SCAN_URL:${link}")
     }
 
     void log(String message) {
@@ -427,5 +448,4 @@ class BuildScanLifeCycleLogger {
             default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int) ch)
         }
     }
-
 }

--- a/agent/src/main/resources/init-scripts/build-scan-collector.groovy
+++ b/agent/src/main/resources/init-scripts/build-scan-collector.groovy
@@ -1,0 +1,36 @@
+// send a message to the server that the build has started
+buildScanCollector.logger = getLogger()
+buildScanCollector.log('BUILD_STARTED')
+
+class BuildScanCollector {
+    Logger logger
+
+    void captureBuildScanLink(String link) {
+        log("BUILD_SCAN_URL:${link}")
+    }
+
+    void log(String message) {
+        logger.quiet(generateBuildScanLifeCycleMessage(message))
+    }
+
+    private static String generateBuildScanLifeCycleMessage(def attribute) {
+        return "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle '${escape(attribute as String)}']" as String
+    }
+
+    private static String escape(String value) {
+        return value?.toCharArray()?.collect { ch -> escapeChar(ch) }?.join()
+    }
+
+    private static String escapeChar(char ch) {
+        String escapeCharacter = "|"
+        switch (ch) {
+            case '\n': return escapeCharacter + "n"
+            case '\r': return escapeCharacter + "r"
+            case '|': return escapeCharacter + "|"
+            case '\'': return escapeCharacter + "\'"
+            case '[': return escapeCharacter + "["
+            case ']': return escapeCharacter + "]"
+            default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int) ch)
+        }
+    }
+}

--- a/agent/src/main/resources/init-scripts/develocity-injection.init.gradle
+++ b/agent/src/main/resources/init-scripts/develocity-injection.init.gradle
@@ -1,6 +1,6 @@
 /*
  * Initscript for injection of Develocity into Gradle builds.
- * Version: v0.5.0-unpublished
+ * Version: v0.5.0
  */
 
 import org.gradle.util.GradleVersion
@@ -413,39 +413,4 @@ static buildScanPublishedAction(def buildScanExtension, BuildScanCollector colle
     }
 }
 
-// send a message to the server that the build has started
-buildScanCollector.logger = getLogger()
-buildScanCollector.log('BUILD_STARTED')
-
-class BuildScanCollector {
-    Logger logger
-
-    void captureBuildScanLink(String link) {
-        log("BUILD_SCAN_URL:${link}")
-    }
-
-    void log(String message) {
-        logger.quiet(generateBuildScanLifeCycleMessage(message))
-    }
-
-    private static String generateBuildScanLifeCycleMessage(def attribute) {
-        return "##teamcity[nu.studer.teamcity.buildscan.buildScanLifeCycle '${escape(attribute as String)}']" as String
-    }
-
-    private static String escape(String value) {
-        return value?.toCharArray()?.collect { ch -> escapeChar(ch) }?.join()
-    }
-
-    private static String escapeChar(char ch) {
-        String escapeCharacter = "|"
-        switch (ch) {
-            case '\n': return escapeCharacter + "n"
-            case '\r': return escapeCharacter + "r"
-            case '|': return escapeCharacter + "|"
-            case '\'': return escapeCharacter + "\'"
-            case '[': return escapeCharacter + "["
-            case ']': return escapeCharacter + "]"
-            default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int) ch)
-        }
-    }
-}
+class BuildScanCollector {}


### PR DESCRIPTION

- Add a copy of the latest reference init-script
- Leverage build-scan capture functionality with custom groovy script
- Compose final `build-scan-init.gradle` from these inputs