### PR TITLE
Update develocity-maven-extension to v1.23.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For Maven builds, the version of the Develocity Maven extension automatically ap
 
 | TC Build Scan plugin version | Injected Develocity Maven extension version | Injected Common CCUD Maven extension version |
 |------------------------------|---------------------------------------------|----------------------------------------------|
-| Next                         | 1.21.4                                      | 2.0.1                                        |
+| Next                         | 1.23.2                                      | 2.0.1                                        |
 | 0.35                         | 1.18.1                                      | 1.12.2                                       |
 | 0.34                         | 1.18                                        | 1.12.2                                       |
 | 0.33                         | 1.16.1                                      | 1.11.1                                       |

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -16,7 +16,7 @@ configurations {
 
 dependencies {
     mvnExtensions project(path: ':agent:service-message-maven-extension', configuration: 'mvnExtension')
-    mvnExtensions 'com.gradle:develocity-maven-extension:1.21.4'
+    mvnExtensions 'com.gradle:develocity-maven-extension:1.23.2'
     mvnExtensions 'com.gradle:common-custom-user-data-maven-extension:2.0.1'
 
     testImplementation gradleTestKit()

--- a/agent/service-message-maven-extension/.mvn/extensions.xml
+++ b/agent/service-message-maven-extension/.mvn/extensions.xml
@@ -3,7 +3,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
-        <version>1.21.4</version>
+        <version>1.23.2</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>

--- a/agent/service-message-maven-extension/pom.xml
+++ b/agent/service-message-maven-extension/pom.xml
@@ -28,13 +28,13 @@
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>gradle-enterprise-maven-extension</artifactId>
-            <version>1.21.4</version>
+            <version>1.23.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>develocity-maven-extension</artifactId>
-            <version>1.21.4</version>
+            <version>1.23.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageListener.java
+++ b/agent/service-message-maven-extension/src/main/java/nu/studer/teamcity/buildscan/agent/servicemessage/BuildScanServiceMessageListener.java
@@ -7,12 +7,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 abstract class BuildScanServiceMessageListener {
 
+    private static final AtomicBoolean hasBeenCalled = new AtomicBoolean(false);
     private final Logger logger = LoggerFactory.getLogger(BuildScanServiceMessageListener.class);
 
     protected void configure(DevelocityAdapter develocity, MavenSession session) {
+        // A bug in DV extension 1.23.1 can result in duplicate listener calls.
+        // This guard will ensure that we only capture the build scan link once per Maven execution.
+        if (hasBeenCalled.getAndSet(true)) {
+            return; // Ignore subsequent calls
+        }
+
         logger.debug("Executing extension: " + getClass().getSimpleName());
 
         // When a Maven build step has an explicitly defined pom.xml file location, TeamCity will run an info goal on it. Ignore build scan publication in this case.

--- a/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
+++ b/agent/src/main/java/nu/studer/teamcity/buildscan/agent/BuildScanServiceMessageInjector.java
@@ -42,7 +42,7 @@ public class BuildScanServiceMessageInjector extends AgentLifeCycleAdapter {
     private static final String MAVEN_RUNNER = "Maven2";
     private static final String MAVEN_CMD_PARAMS = "runnerArgs";
     private static final String BUILD_SCAN_EXT_MAVEN = "service-message-maven-extension-1.0.jar";
-    private static final String DEVELOCITY_EXT_MAVEN = "develocity-maven-extension-1.21.4.jar";
+    private static final String DEVELOCITY_EXT_MAVEN = "develocity-maven-extension-1.23.2.jar";
     private static final String COMMON_CUSTOM_USER_DATA_EXT_MAVEN = "common-custom-user-data-maven-extension-2.0.1.jar";
 
     // TeamCity Command-line runner

--- a/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/BaseExtensionApplicationTest.groovy
+++ b/agent/src/test/groovy/nu/studer/teamcity/buildscan/agent/maven/BaseExtensionApplicationTest.groovy
@@ -38,7 +38,7 @@ abstract class BaseExtensionApplicationTest extends Specification {
 
     static final String DEVELOCITY_URL_STR = System.getenv('DEVELOCITY_TEST_INSTANCE')
     static final URI DEVELOCITY_URL = DEVELOCITY_URL_STR ? new URI(DEVELOCITY_URL_STR) : null
-    static final String DEVELOCITY_EXTENSION_VERSION = '1.21.4'
+    static final String DEVELOCITY_EXTENSION_VERSION = '1.23.2'
     static final String CCUD_EXTENSION_VERSION = '2.0.1'
 
     @TempDir

--- a/src/main/resources/default-plugin-versions.properties
+++ b/src/main/resources/default-plugin-versions.properties
@@ -1,4 +1,4 @@
 gradleEnterprisePluginVersion=3.19.2
 commonCustomUserDataPluginVersion=2.2.1
-gradleEnterpriseExtensionVersion=1.21.4
+gradleEnterpriseExtensionVersion=1.23.2
 commonCustomUserDataExtensionVersion=2.0

--- a/src/test/groovy/nu/studer/teamcity/buildscan/connection/DevelocityConnectionProviderTest.groovy
+++ b/src/test/groovy/nu/studer/teamcity/buildscan/connection/DevelocityConnectionProviderTest.groovy
@@ -51,7 +51,7 @@ class DevelocityConnectionProviderTest extends Specification {
         ALLOW_UNTRUSTED_SERVER                  | 'true'                          | 'Allow Untrusted Server'
         DEVELOCITY_PLUGIN_VERSION               | '3.19.2'                        | 'Develocity Gradle Plugin Version'
         CCUD_PLUGIN_VERSION                     | '2.2.1'                         | 'Common Custom User Data Gradle Plugin Version'
-        DEVELOCITY_EXTENSION_VERSION            | '1.21.4'                        | 'Develocity Maven Extension Version'
+        DEVELOCITY_EXTENSION_VERSION            | '1.23.2'                        | 'Develocity Maven Extension Version'
         CCUD_EXTENSION_VERSION                  | '2.0.1'                         | 'Common Custom User Data Maven Extension Version'
         CUSTOM_DEVELOCITY_EXTENSION_COORDINATES | 'com.company:my-ge-extension'   | 'Develocity Maven Extension Custom Coordinates'
         CUSTOM_CCUD_EXTENSION_COORDINATES       | 'com.company:my-ccud-extension' | 'Common Custom User Data Maven Extension Custom Coordinates'


### PR DESCRIPTION
Updated DV extension version everywhere:
- Update bundled version
- Update default version applied in tests
- Update version used by Maven build
- Update all doc references

Adds a static guard to prevent duplicate listener calls due to bug in 1.23.1